### PR TITLE
Rename 'port-scan' command to 'scan-targets'

### DIFF
--- a/src/app/connect/connect-button.component.ts
+++ b/src/app/connect/connect-button.component.ts
@@ -20,7 +20,7 @@ export class ConnectButtonComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.subscriptions.push(
-      this.svc.onResponse('port-scan')
+      this.svc.onResponse('scan-targets')
         .subscribe(r => {
           this.hosts = (r as ListMessage).payload;
           if (this.hosts.length === 1) {
@@ -34,7 +34,7 @@ export class ConnectButtonComponent implements OnInit, OnDestroy {
         first()
       )
       .subscribe(() => {
-        this.svc.sendMessage('port-scan');
+        this.svc.sendMessage('scan-targets');
       });
     this.svc.onResponse('is-connected')
       .pipe(
@@ -54,7 +54,7 @@ export class ConnectButtonComponent implements OnInit, OnDestroy {
     if (host === 'rescan') {
       this.hosts = [];
       this.host = '';
-      this.svc.sendMessage('port-scan');
+      this.svc.sendMessage('scan-targets');
     } else if (host.trim().length > 0) {
       this.svc.sendMessage('disconnect');
       this.svc.sendMessage('connect', [ host.trim() ]);


### PR DESCRIPTION
Here is the front-end side of the command name change in https://github.com/rh-jmc-team/container-jfr/pull/2. Seems to work fine when deployed. Let me know if I missed something.