### PR TITLE
Remove upload-recording onResponse from archived list

### DIFF
--- a/src/app/recording-list/archived/archived-recording-list.component.ts
+++ b/src/app/recording-list/archived/archived-recording-list.component.ts
@@ -66,19 +66,6 @@ export class ArchivedRecordingListComponent implements OnInit, OnDestroy {
       ).subscribe(() => this.grafanaEnabled = true)
     );
 
-    this.subscriptions.push(
-      this.svc.onResponse('upload-recording')
-        .subscribe((r: ResponseMessage<UploadResponse>) => {
-          if (r.status === 0) {
-            this.notifications.message(
-              NotificationType.SUCCESS, 'Upload success', null, false, null, null
-            );
-            this.http.get('/grafana_dashboard_url')
-              .subscribe((url: { grafanaDashboardUrl: string }) => window.open(url.grafanaDashboardUrl, '_blank'));
-          }
-        })
-    );
-
     this.refreshList();
   }
 


### PR DESCRIPTION
Current recording list is always present, so archived list's
upload-recording handler is redundant and causes duplicate handling of
the response message

Fixes #17