### PR TITLE
Use message IDs to prevent spurious notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8819,6 +8819,14 @@
         "tough-cookie": "~2.4.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "require-directory": {
@@ -9534,6 +9542,14 @@
       "requires": {
         "faye-websocket": "^0.10.0",
         "uuid": "^3.0.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "sockjs-client": {
@@ -10755,10 +10771,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
+      "integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -11240,6 +11255,14 @@
       "requires": {
         "ansi-colors": "^3.0.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "webpack-merge": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "core-js": "^2.5.4",
     "rxjs": "~6.3.3",
     "tslib": "^1.9.0",
+    "uuid": "^7.0.2",
     "zone.js": "~0.8.26"
   },
   "devDependencies": {

--- a/src/app/command-channel.service.ts
+++ b/src/app/command-channel.service.ts
@@ -4,6 +4,7 @@ import { filter, first, map } from 'rxjs/operators';
 import { HttpClient } from '@angular/common/http';
 import { NotificationService, NotificationType } from 'patternfly-ng/notification';
 import { ApiService } from './api.service';
+import * as uuid from 'uuid';
 
 @Injectable()
 export class CommandChannelService implements OnDestroy {
@@ -130,10 +131,12 @@ export class CommandChannelService implements OnDestroy {
     this.ws.addEventListener('close', handler);
   }
 
-  sendMessage(command: string, args: string[] = [], id: string = null): void {
+  sendMessage(command: string, args: string[] = []): string {
+    const id = uuid.v4();
     if (this.ws) {
       this.ws.send(JSON.stringify({ id, command, args } as CommandMessage));
     }
+    return id;
   }
 
   onResponse(command: string): Observable<ResponseMessage<any>> {

--- a/src/app/command-channel.service.ts
+++ b/src/app/command-channel.service.ts
@@ -148,8 +148,8 @@ export class CommandChannelService implements OnDestroy {
   }
 }
 
-export interface CommandMessage {
-  id?: string;
+interface CommandMessage {
+  id: string;
   command: string;
   args?: string[];
 }

--- a/src/app/command-channel.service.ts
+++ b/src/app/command-channel.service.ts
@@ -130,9 +130,9 @@ export class CommandChannelService implements OnDestroy {
     this.ws.addEventListener('close', handler);
   }
 
-  sendMessage(command: string, args: string[] = []): void {
+  sendMessage(command: string, args: string[] = [], id: string = null): void {
     if (this.ws) {
-      this.ws.send(JSON.stringify({ command, args } as CommandMessage));
+      this.ws.send(JSON.stringify({ id, command, args } as CommandMessage));
     }
   }
 
@@ -146,11 +146,13 @@ export class CommandChannelService implements OnDestroy {
 }
 
 export interface CommandMessage {
+  id?: string;
   command: string;
   args?: string[];
 }
 
 export interface ResponseMessage<T> {
+  id: string;
   status: number;
   commandName: string;
   payload: T;

--- a/src/app/recording-list/current/current-recording-list.component.ts
+++ b/src/app/recording-list/current/current-recording-list.component.ts
@@ -10,7 +10,6 @@ import { CommandChannelService, ResponseMessage } from '../../command-channel.se
 import { ConfirmationDialogComponent } from '../../confirmation-dialog/confirmation-dialog.component';
 import { CreateRecordingComponent } from '../../create-recording/create-recording.component';
 import { UploadResponse } from '../recording-list.component';
-import * as uuid from 'uuid';
 
 export enum ConnectionState {
   UNKNOWN,
@@ -220,7 +219,9 @@ export class CurrentRecordingListComponent implements OnInit, OnDestroy {
   }
 
   save(name: string): void {
-    this.svc.sendMessage('save', [ name ], this.createMessageUuid());
+    this.awaitingMsgIds.add(
+      this.svc.sendMessage('save', [ name ])
+    );
   }
 
   download(recording: Recording): void {
@@ -249,7 +250,9 @@ export class CurrentRecordingListComponent implements OnInit, OnDestroy {
       this.notifications.message(
         NotificationType.INFO, 'Upload started', null, false, null, null
       );
-      this.svc.sendMessage('upload-recording', [ name, `${grafana}/load` ], this.createMessageUuid());
+      this.awaitingMsgIds.add(
+        this.svc.sendMessage('upload-recording', [ name, `${grafana}/load` ])
+      );
     });
   }
 
@@ -272,12 +275,6 @@ export class CurrentRecordingListComponent implements OnInit, OnDestroy {
         duration: -1
       }
     });
-  }
-
-  private createMessageUuid(): string {
-    const id = uuid.v4();
-    this.awaitingMsgIds.add(id);
-    return id;
   }
 
 }


### PR DESCRIPTION
Most of the time, container-jfr-web doesn't need to care about message IDs,
since each incoming message is either disregarded in general, or contains
useful information about a container-jfr side (or remote JVM side) state
change, which the UI should track regardless of which client initiated the
action resulting in this state change.

There are two UI-specific cases where this can and should be avoided:
- when displaying a notification after saving a recording to storage
- when opening a Grafana tab after uploading a recording

This PR uses message ID tracking to correct the behaviour so that these
notifications and tabs are only displayed/opened when the response
corresponds to an action that the user of this client instance
initiated.