### PR TITLE
Add TargetSelect widget on RecordingList

### DIFF
--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -9,7 +9,7 @@ export const Dashboard = (props) => {
       <Title size="lg">Dashboard</Title>
       <Grid gutter="md">
         <GridItem span={8}>
-          <TargetSelect />
+          <TargetSelect allowDisconnect={true} />
         </GridItem>
       </Grid>
     </PageSection>

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { Grid, GridItem, PageSection, Title } from '@patternfly/react-core';
+import { TargetSelect } from '@app/TargetSelect/TargetSelect';
+
+export const Dashboard = (props) => {
+
+  return (
+    <PageSection>
+      <Title size="lg">Dashboard</Title>
+      <Grid gutter="md">
+        <GridItem span={8}>
+          <TargetSelect />
+        </GridItem>
+      </Grid>
+    </PageSection>
+  );
+
+}

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -5,7 +5,7 @@ import { TargetView } from '@app/TargetView/TargetView';
 export const Dashboard = (props) => {
 
   return (
-    <TargetView pageTitle="Dashboard" allowDisconnect={true} targetSelectWidth={8} />
+    <TargetView pageTitle="Dashboard" allowDisconnect={true} compactSelect={false} />
   );
 
 }

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -1,18 +1,11 @@
 import * as React from 'react';
 import { Grid, GridItem, PageSection, Title } from '@patternfly/react-core';
-import { TargetSelect } from '@app/TargetSelect/TargetSelect';
+import { TargetView } from '@app/TargetView/TargetView';
 
 export const Dashboard = (props) => {
 
   return (
-    <PageSection>
-      <Title size="lg">Dashboard</Title>
-      <Grid gutter="md">
-        <GridItem span={8}>
-          <TargetSelect allowDisconnect={true} />
-        </GridItem>
-      </Grid>
-    </PageSection>
+    <TargetView pageTitle="Dashboard" allowDisconnect={true} targetSelectWidth={8} />
   );
 
 }

--- a/src/app/RecordingList/RecordingList.tsx
+++ b/src/app/RecordingList/RecordingList.tsx
@@ -68,7 +68,7 @@ export const RecordingList = (props) => {
   }, []);
 
   return (
-    <TargetView pageTitle="Flight Recordings" allowDisconnect={false}>
+    <TargetView pageTitle="Flight Recordings">
       <Table aria-label="Recordings Table" cells={tableColumns} rows={getRecordingRows()}>
         <TableHeader />
         <TableBody />

--- a/src/app/RecordingList/RecordingList.tsx
+++ b/src/app/RecordingList/RecordingList.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { filter, map } from 'rxjs/operators';
-import { Grid, GridItem, PageSection, Title } from '@patternfly/react-core';
+import { Card, CardBody, CardHeader, PageSection, Text, TextVariants, Title } from '@patternfly/react-core';
 import { Table, TableHeader, TableBody, textCenter } from '@patternfly/react-table';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { TargetView } from '@app/TargetView/TargetView';
@@ -69,10 +69,15 @@ export const RecordingList = (props) => {
 
   return (
     <TargetView pageTitle="Flight Recordings">
-      <Table aria-label="Recordings Table" cells={tableColumns} rows={getRecordingRows()}>
-        <TableHeader />
-        <TableBody />
-      </Table>
+      <Card>
+        <CardHeader><Text component={TextVariants.h4}>Active Recordings</Text></CardHeader>
+        <CardBody>
+          <Table aria-label="Recordings Table" cells={tableColumns} rows={getRecordingRows()}>
+            <TableHeader />
+            <TableBody />
+          </Table>
+        </CardBody>
+      </Card>
     </TargetView>
   );
 };

--- a/src/app/RecordingList/RecordingList.tsx
+++ b/src/app/RecordingList/RecordingList.tsx
@@ -3,6 +3,7 @@ import { filter, map } from 'rxjs/operators';
 import { Grid, GridItem, PageSection, Title } from '@patternfly/react-core';
 import { Table, TableHeader, TableBody, textCenter } from '@patternfly/react-table';
 import { ServiceContext } from '@app/Shared/Services/Services';
+import { TargetSelect } from '@app/TargetSelect/TargetSelect';
 
 interface Recording {
   id: number;
@@ -68,9 +69,12 @@ export const RecordingList = (props) => {
 
   return (
     <PageSection>
-      <Grid>
+      <Title size="lg">JDK Flight Recordings</Title>
+      <Grid gutter="md">
+        <GridItem span={6}>
+          <TargetSelect />
+        </GridItem>
         <GridItem span={12}>
-          <Title size="lg">JDK Flight Recordings</Title>
           <Table aria-label="Recordings Table" cells={tableColumns} rows={getRecordingRows()}>
             <TableHeader />
             <TableBody />

--- a/src/app/RecordingList/RecordingList.tsx
+++ b/src/app/RecordingList/RecordingList.tsx
@@ -3,7 +3,7 @@ import { filter, map } from 'rxjs/operators';
 import { Grid, GridItem, PageSection, Title } from '@patternfly/react-core';
 import { Table, TableHeader, TableBody, textCenter } from '@patternfly/react-table';
 import { ServiceContext } from '@app/Shared/Services/Services';
-import { TargetSelect } from '@app/TargetSelect/TargetSelect';
+import { TargetView } from '@app/TargetView/TargetView';
 
 interface Recording {
   id: number;
@@ -68,19 +68,11 @@ export const RecordingList = (props) => {
   }, []);
 
   return (
-    <PageSection>
-      <Title size="lg">JDK Flight Recordings</Title>
-      <Grid gutter="md">
-        <GridItem span={6}>
-          <TargetSelect />
-        </GridItem>
-        <GridItem span={12}>
-          <Table aria-label="Recordings Table" cells={tableColumns} rows={getRecordingRows()}>
-            <TableHeader />
-            <TableBody />
-          </Table>
-        </GridItem>
-      </Grid>
-    </PageSection>
+    <TargetView pageTitle="Flight Recordings" allowDisconnect={false}>
+      <Table aria-label="Recordings Table" cells={tableColumns} rows={getRecordingRows()}>
+        <TableHeader />
+        <TableBody />
+      </Table>
+    </TargetView>
   );
 };

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { distinctUntilChanged, filter, first } from 'rxjs/operators';
-import { Grid, GridItem, PageSection, Select, SelectOption, SelectVariant, Text, TextVariants, Title } from '@patternfly/react-core';
+import { Card, CardBody, CardHeader, Grid, GridItem, PageSection, Select, SelectOption, SelectVariant, Text, TextVariants, Title } from '@patternfly/react-core';
 import { ContainerNodeIcon } from '@patternfly/react-icons';
 import { ServiceContext } from '@app/Shared/Services/Services';
 
@@ -79,34 +79,38 @@ export const TargetSelect = (props: TargetSelectProps) => {
 
   return (<>
       <Grid>
-        <GridItem>
-          <Text component={TextVariants.p}>
-            Target JVM
-          </Text>
-        </GridItem>
         <GridItem span={props.isCompact ? 2 : 8}>
-          <Select
-            toggleIcon={<ContainerNodeIcon />}
-            variant={SelectVariant.single}
-            selections={selected}
-            onSelect={onSelect}
-            onToggle={setExpanded}
-            isExpanded={expanded}
-            aria-label="Select Input"
-          >
-          {
-            (props.allowDisconnect ? [<SelectOption key='placeholder' value='Select Target...' isPlaceholder={true} />] : [])
-              .concat(
-                targets.map((t: Target) => (
-                  <SelectOption
-                    key={t.connectUrl}
-                    value={t}
-                    isPlaceholder={false}
-                  >{`${t.alias} (${t.connectUrl})`}</SelectOption>
-                ))
-            )
-          }
-          </Select>
+          <Card>
+            <CardHeader>
+              <Text component={TextVariants.h4}>
+                Target JVM
+              </Text>
+            </CardHeader>
+            <CardBody>
+              <Select
+                toggleIcon={<ContainerNodeIcon />}
+                variant={SelectVariant.single}
+                selections={selected}
+                onSelect={onSelect}
+                onToggle={setExpanded}
+                isExpanded={expanded}
+                aria-label="Select Input"
+              >
+              {
+                (props.allowDisconnect ? [<SelectOption key='placeholder' value='Select Target...' isPlaceholder={true} />] : [])
+                  .concat(
+                    targets.map((t: Target) => (
+                      <SelectOption
+                        key={t.connectUrl}
+                        value={t}
+                        isPlaceholder={false}
+                      >{`${t.alias} (${t.connectUrl})`}</SelectOption>
+                    ))
+                )
+              }
+              </Select>
+            </CardBody>
+          </Card>
         </GridItem>
       </Grid>
   </>);

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -4,13 +4,17 @@ import { PageSection, Select, SelectOption, SelectVariant, Title } from '@patter
 import { ContainerNodeIcon } from '@patternfly/react-icons';
 import { ServiceContext } from '@app/Shared/Services/Services';
 
+export interface TargetSelectProps {
+  allowDisconnect: boolean;
+}
+
 interface Target {
   connectUrl: string;
   alias: string;
   port: number;
 }
 
-export const TargetSelect = (props) => {
+export const TargetSelect = (props: TargetSelectProps) => {
   const context = React.useContext(ServiceContext);
   const [selected, setSelected] = React.useState('');
   const [targets, setTargets] = React.useState([]);
@@ -82,7 +86,7 @@ export const TargetSelect = (props) => {
         aria-label="Select Input"
       >
       {
-        [<SelectOption key='placeholder' value='Select Target...' isPlaceholder={true} />]
+        (props.allowDisconnect ? [<SelectOption key='placeholder' value='Select Target...' isPlaceholder={true} />] : [])
           .concat(
             targets.map((t: Target) => (
               <SelectOption

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -58,7 +58,7 @@ export const TargetSelect = (props: TargetSelectProps) => {
   }, []);
 
   const connect = (target: Target) => {
-    context.commandChannel.sendMessage('connect', [ target.connectUrl ]);
+    context.commandChannel.sendMessage('connect', [ `${target.connectUrl}:${target.port}` ]);
   };
 
   const disconnect = () => {
@@ -104,7 +104,7 @@ export const TargetSelect = (props: TargetSelectProps) => {
                         key={t.connectUrl}
                         value={t}
                         isPlaceholder={false}
-                      >{`${t.alias} (${t.connectUrl})`}</SelectOption>
+                      >{`${t.alias} (${t.connectUrl}:${t.port})`}</SelectOption>
                     ))
                 )
               }

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -50,8 +50,11 @@ export const TargetSelect = (props: TargetSelectProps) => {
   }, []);
 
   React.useEffect(() => {
-    context.commandChannel.sendMessage('is-connected');
-  });
+    const sub = context.commandChannel.isReady().pipe(filter(v => v!!), first()).subscribe(() => {
+      context.commandChannel.sendMessage('is-connected');
+    });
+    return () => sub.unsubscribe();
+  }, []);
 
   const connect = (target: Target) => {
     context.commandChannel.sendMessage('connect', [ target.connectUrl ]);

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { distinctUntilChanged, filter, first } from 'rxjs/operators';
-import { PageSection, Select, SelectOption, SelectVariant, Title } from '@patternfly/react-core';
+import { Grid, GridItem, PageSection, Select, SelectOption, SelectVariant, Text, TextVariants, Title } from '@patternfly/react-core';
 import { ContainerNodeIcon } from '@patternfly/react-icons';
 import { ServiceContext } from '@app/Shared/Services/Services';
 
 export interface TargetSelectProps {
-  allowDisconnect: boolean;
+  isCompact?: boolean;
+  allowDisconnect?: boolean;
 }
 
 interface Target {
@@ -76,32 +77,38 @@ export const TargetSelect = (props: TargetSelectProps) => {
     setExpanded(false);
   };
 
-  return (
-    <>
-      <div>Active Connection: {selected}</div>
-      <Select
-        toggleIcon={<ContainerNodeIcon />}
-        variant={SelectVariant.single}
-        selections={selected}
-        onSelect={onSelect}
-        onToggle={setExpanded}
-        isExpanded={expanded}
-        aria-label="Select Input"
-      >
-      {
-        (props.allowDisconnect ? [<SelectOption key='placeholder' value='Select Target...' isPlaceholder={true} />] : [])
-          .concat(
-            targets.map((t: Target) => (
-              <SelectOption
-                key={t.connectUrl}
-                value={t}
-                isPlaceholder={false}
-              >{`${t.alias} (${t.connectUrl})`}</SelectOption>
-            ))
-        )
-      }
-      </Select>
-    </>
-  );
+  return (<>
+      <Grid>
+        <GridItem>
+          <Text component={TextVariants.p}>
+            Target JVM
+          </Text>
+        </GridItem>
+        <GridItem span={props.isCompact ? 2 : 8}>
+          <Select
+            toggleIcon={<ContainerNodeIcon />}
+            variant={SelectVariant.single}
+            selections={selected}
+            onSelect={onSelect}
+            onToggle={setExpanded}
+            isExpanded={expanded}
+            aria-label="Select Input"
+          >
+          {
+            (props.allowDisconnect ? [<SelectOption key='placeholder' value='Select Target...' isPlaceholder={true} />] : [])
+              .concat(
+                targets.map((t: Target) => (
+                  <SelectOption
+                    key={t.connectUrl}
+                    value={t}
+                    isPlaceholder={false}
+                  >{`${t.alias} (${t.connectUrl})`}</SelectOption>
+                ))
+            )
+          }
+          </Select>
+        </GridItem>
+      </Grid>
+  </>);
 
 }

--- a/src/app/TargetView/TargetView.tsx
+++ b/src/app/TargetView/TargetView.tsx
@@ -6,7 +6,7 @@ interface TargetViewProps {
   children?: any;
   pageTitle: string;
   targetSelectWidth?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
-  compactSelect: boolean;
+  compactSelect?: boolean;
   allowDisconnect?: boolean;
 }
 

--- a/src/app/TargetView/TargetView.tsx
+++ b/src/app/TargetView/TargetView.tsx
@@ -5,6 +5,7 @@ import { TargetSelect } from '@app/TargetSelect/TargetSelect';
 interface TargetViewProps {
   children: any;
   pageTitle: string;
+  targetSelectWidth?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
   allowDisconnect?: boolean;
 }
 
@@ -14,7 +15,7 @@ export const TargetView = (props: TargetViewProps) => {
     <PageSection>
       <Title size="lg">{props.pageTitle}</Title>
       <Grid gutter="md">
-        <GridItem span={4}>
+        <GridItem span={props.targetSelectWidth || 4}>
           <TargetSelect allowDisconnect={props.allowDisconnect || false} />
         </GridItem>
         {

--- a/src/app/TargetView/TargetView.tsx
+++ b/src/app/TargetView/TargetView.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { Grid, GridItem, PageSection, Title } from '@patternfly/react-core';
+import { PageSection, Stack, StackItem, Title } from '@patternfly/react-core';
 import { TargetSelect } from '@app/TargetSelect/TargetSelect';
 
 interface TargetViewProps {
-  children: any;
+  children?: any;
   pageTitle: string;
   targetSelectWidth?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+  compactSelect: boolean;
   allowDisconnect?: boolean;
 }
 
@@ -14,18 +15,18 @@ export const TargetView = (props: TargetViewProps) => {
   return (<>
     <PageSection>
       <Title size="lg">{props.pageTitle}</Title>
-      <Grid gutter="md">
-        <GridItem span={props.targetSelectWidth || 4}>
-          <TargetSelect allowDisconnect={props.allowDisconnect || false} />
-        </GridItem>
+      <Stack gutter="md">
+        <StackItem>
+          <TargetSelect isCompact={props.compactSelect == null ? true : props.compactSelect} allowDisconnect={props.allowDisconnect || false} />
+        </StackItem>
         {
           React.Children.map(props.children, child => (
-            <GridItem span={12}>
+            <StackItem isFilled>
               {child}
-            </GridItem>
+            </StackItem>
           ))
         }
-      </Grid>
+      </Stack>
     </PageSection>
   </>);
 

--- a/src/app/TargetView/TargetView.tsx
+++ b/src/app/TargetView/TargetView.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { Grid, GridItem, PageSection, Title } from '@patternfly/react-core';
+import { TargetSelect } from '@app/TargetSelect/TargetSelect';
+
+interface TargetViewProps {
+  children: any;
+  pageTitle: string;
+  allowDisconnect: boolean;
+}
+
+export const TargetView = (props: TargetViewProps) => {
+
+  return (<>
+    <PageSection>
+      <Title size="lg">{props.pageTitle}</Title>
+      <Grid gutter="md">
+        <GridItem span={4}>
+          <TargetSelect allowDisconnect={props.allowDisconnect} />
+        </GridItem>
+        <GridItem span={12}>
+          {props.children}
+        </GridItem>
+      </Grid>
+    </PageSection>
+  </>);
+
+}

--- a/src/app/TargetView/TargetView.tsx
+++ b/src/app/TargetView/TargetView.tsx
@@ -5,7 +5,7 @@ import { TargetSelect } from '@app/TargetSelect/TargetSelect';
 interface TargetViewProps {
   children: any;
   pageTitle: string;
-  allowDisconnect: boolean;
+  allowDisconnect?: boolean;
 }
 
 export const TargetView = (props: TargetViewProps) => {
@@ -15,7 +15,7 @@ export const TargetView = (props: TargetViewProps) => {
       <Title size="lg">{props.pageTitle}</Title>
       <Grid gutter="md">
         <GridItem span={4}>
-          <TargetSelect allowDisconnect={props.allowDisconnect} />
+          <TargetSelect allowDisconnect={props.allowDisconnect || false} />
         </GridItem>
         <GridItem span={12}>
           {props.children}

--- a/src/app/TargetView/TargetView.tsx
+++ b/src/app/TargetView/TargetView.tsx
@@ -17,9 +17,13 @@ export const TargetView = (props: TargetViewProps) => {
         <GridItem span={4}>
           <TargetSelect allowDisconnect={props.allowDisconnect || false} />
         </GridItem>
-        <GridItem span={12}>
-          {props.children}
-        </GridItem>
+        {
+          React.Children.map(props.children, child => (
+            <GridItem span={12}>
+              {child}
+            </GridItem>
+          ))
+        }
       </Grid>
     </PageSection>
   </>);

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -7,8 +7,8 @@ import { NotFound } from '@app/NotFound/NotFound';
 import { useDocumentTitle } from '@app/utils/useDocumentTitle';
 import { LastLocationProvider, useLastLocation } from 'react-router-last-location';
 import { ServiceContext } from '@app/Shared/Services/Services';
-import { TargetSelect } from '@app/TargetSelect/TargetSelect';
 import { Login } from '@app/Login/Login';
+import { Dashboard } from '@app/Dashboard/Dashboard';
 import { RecordingList } from '@app/RecordingList/RecordingList';
 
 let routeFocusTimer: number;
@@ -26,11 +26,11 @@ export interface IAppRoute {
 
 const staticRoutes: IAppRoute[] = [
   {
-    component: TargetSelect,
+    component: Dashboard,
     exact: true,
-    label: 'Target Selection',
+    label: 'Dashboard',
     path: '/',
-    title: 'ContainerJFR Target Selection'
+    title: 'ContainerJFR Dashboard'
   },
 ];
 

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -30,7 +30,7 @@ const staticRoutes: IAppRoute[] = [
     exact: true,
     label: 'Dashboard',
     path: '/',
-    title: 'ContainerJFR Dashboard'
+    title: 'Dashboard'
   },
 ];
 
@@ -40,7 +40,7 @@ const dynamicRoutes: IAppRoute[] = [
     exact: true,
     label: 'Recordings',
     path: '/recordings',
-    title: 'JDK Flight Recordings'
+    title: 'Flight Recordings'
   },
 ];
 


### PR DESCRIPTION
![container-jfr-web-react-targetselect](https://user-images.githubusercontent.com/3787464/78941098-87386000-7aa6-11ea-88f7-cc47874abc3e.gif)

This PR modifies the TargetSelect component so that it can be reused, reinstates the Dashboard main page component containing a TargetSelect, and adds a TargetSelect to the RecordingList. The intent is to allow users to quickly switch targets while remaining on the same content view, without needing to click back and forth between the previous standalone target selection view.