### PR TITLE
Initial Events view

### DIFF
--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -24,10 +24,11 @@ export const EventTemplates = (props) => {
 
   const getTemplates = () => {
     let filtered;
-    if (!filter) {
+    if (!filterText) {
       filtered = templates;
     } else {
-      filtered = templates.filter((t: EventTemplate) => t.name.toLowerCase().includes(filterText) || t.description.toLowerCase().includes(filterText) || t.provider.toLowerCase().includes(filterText));
+      const ft = filterText.trim().toLowerCase();
+      filtered = templates.filter((t: EventTemplate) => t.name.toLowerCase().includes(ft) || t.description.toLowerCase().includes(ft) || t.provider.toLowerCase().includes(ft));
     }
     return filtered.map((t: EventTemplate) =>
       [ t.name, t.description, t.provider ]

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { filter, map } from 'rxjs/operators';
+import { TextInput, Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
 import { Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { ServiceContext } from '@app/Shared/Services/Services';
 
@@ -13,6 +14,7 @@ export const EventTemplates = (props) => {
   const context = React.useContext(ServiceContext);
 
   const [templates, setTemplates] = React.useState([]);
+  const [filterText, setFilterText] = React.useState('');
 
   const tableColumns = [
     'Name',
@@ -21,10 +23,16 @@ export const EventTemplates = (props) => {
   ];
 
   const getTemplates = () => {
-    return templates.map((t: EventTemplate) => {
-      return [ t.name, t.description, t.provider ];
-    })
-  }
+    let filtered;
+    if (!filter) {
+      filtered = templates;
+    } else {
+      filtered = templates.filter((t: EventTemplate) => t.name.toLowerCase().includes(filterText) || t.description.toLowerCase().includes(filterText) || t.provider.toLowerCase().includes(filterText));
+    }
+    return filtered.map((t: EventTemplate) =>
+      [ t.name, t.description, t.provider ]
+    );
+  };
 
   React.useEffect(() => {
     const sub = context.commandChannel.onResponse('list-event-templates')
@@ -40,11 +48,18 @@ export const EventTemplates = (props) => {
     context.commandChannel.sendMessage('list-event-templates');
   }, []);
 
-  return(
+  return(<>
+    <Toolbar>
+      <ToolbarGroup>
+        <ToolbarItem>
+          <TextInput name="templateFilter" id="templateFilter" type="search" placeholder="Filter..." aria-label="Event template filter" onChange={setFilterText}/>
+        </ToolbarItem>
+      </ToolbarGroup>
+    </Toolbar>
     <Table aria-label="Event Templates table" cells={tableColumns} rows={getTemplates()}>
       <TableHeader />
       <TableBody />
     </Table>
-  );
+  </>);
 
 }

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { filter, map } from 'rxjs/operators';
 import { TextInput, Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
-import { Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-table';
 import { ServiceContext } from '@app/Shared/Services/Services';
 
 export interface EventTemplate {
@@ -56,7 +56,7 @@ export const EventTemplates = (props) => {
         </ToolbarItem>
       </ToolbarGroup>
     </Toolbar>
-    <Table aria-label="Event Templates table" cells={tableColumns} rows={getTemplates()}>
+    <Table aria-label="Event Templates table" cells={tableColumns} rows={getTemplates()} variant={TableVariant.compact}>
       <TableHeader />
       <TableBody />
     </Table>

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { filter, map } from 'rxjs/operators';
+import { Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { ServiceContext } from '@app/Shared/Services/Services';
+
+export interface EventTemplate {
+  name: string;
+  description: string;
+  provider: string;
+}
+
+export const EventTemplates = (props) => {
+  const context = React.useContext(ServiceContext);
+
+  const [templates, setTemplates] = React.useState([]);
+
+  const tableColumns = [
+    'Name',
+    'Description',
+    'Provider',
+  ];
+
+  const getTemplates = () => {
+    return templates.map((t: EventTemplate) => {
+      return [ t.name, t.description, t.provider ];
+    })
+  }
+
+  React.useEffect(() => {
+    const sub = context.commandChannel.onResponse('list-event-templates')
+      .pipe(
+        filter(m => m.status === 0),
+        map(m => m.payload),
+      )
+      .subscribe(templates => setTemplates(templates));
+    return () => sub.unsubscribe();
+  }, []);
+
+  React.useEffect(() => {
+    context.commandChannel.sendMessage('list-event-templates');
+  }, []);
+
+  return(
+    <Table aria-label="Event Templates table" cells={tableColumns} rows={getTemplates()}>
+      <TableHeader />
+      <TableBody />
+    </Table>
+  );
+
+}

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -132,7 +132,7 @@ export const EventTypes = (props) => {
       <SplitItem isFilled />
       <SplitItem>
         <Pagination
-          itemCount={!!filterText ? displayedTypes.length : types.length}
+          itemCount={!!filterText ? filterTypesByText(types, filterText).length : types.length}
           page={currentPage}
           perPage={perPage}
           onSetPage={onCurrentPage}

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -58,7 +58,7 @@ export const EventTypes = (props) => {
 
     const rows: any[] = [];
     page.forEach((t: EventType, idx: number) => {
-      rows.push({ cells: [ t.name, t.typeId, t.description, t.category.join(', ').trim() ], isOpen: (idx === openRow) });
+      rows.push({ cells: [ t.name, t.typeId, t.description, getCategoryString(t) ], isOpen: (idx === openRow) });
       if (idx === openRow) {
         let child = '';
         for (const opt in t.options) {
@@ -70,6 +70,10 @@ export const EventTypes = (props) => {
 
     setDisplayedTypes(rows);
   }, [currentPage, perPage, types, openRow, filterText]);
+
+  const getCategoryString = (eventType: EventType): string => {
+    return eventType.category.join(', ').trim();
+  };
 
   const filterTypesByText = (types, filter) => {
     if (!filter) {
@@ -86,7 +90,7 @@ export const EventTypes = (props) => {
       if (includesSubstr(t.description, filter)) {
         return true;
       }
-      if (t.category.some(c => includesSubstr(c, filter))) {
+      if (includesSubstr(getCategoryString(t), filter)) {
         return true;
       }
       return false

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -25,6 +25,7 @@ export const EventTypes = (props) => {
   const [displayedTypes, setDisplayedTypes] = React.useState([] as any[]);
   const [currentPage, setCurrentPage] = React.useState(1);
   const [perPage, setPerPage] = React.useState(10);
+  const prevPerPage = React.useRef(10);
   const [openRow, setOpenRow] = React.useState(-1);
   const [filterText, setFilterText] = React.useState('');
 
@@ -102,7 +103,13 @@ export const EventTypes = (props) => {
     setCurrentPage(currentPage);
   };
 
-  const onPerPage = (evt, perPage) => setPerPage(perPage);
+  const onPerPage = (evt, perPage) => {
+    const offset = (currentPage - 1) * prevPerPage.current;
+    prevPerPage.current = perPage;
+    setOpenRow(-1);
+    setPerPage(perPage);
+    setCurrentPage(1 + Math.floor(offset/perPage));
+  };
 
   const onCollapse = (event, rowKey, isOpen) => {
     if (isOpen) {

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import { filter, map } from 'rxjs/operators';
+import { Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { ServiceContext } from '@app/Shared/Services/Services';
+
+export interface EventType {
+  name: string;
+  typeId: string;
+  description: string;
+  category: string[];
+  options: Map<string, OptionDescriptor>;
+}
+
+export interface OptionDescriptor {
+  name: string;
+  description: string;
+  defaultValue: string;
+}
+
+export const EventTypes = (props) => {
+  const context = React.useContext(ServiceContext);
+
+  const [types, setTypes] = React.useState([]);
+
+  const tableColumns = [
+    'Name',
+    'Type ID',
+    'Description',
+    'Categories',
+    'Options',
+  ];
+
+  const getEventTypes = () => {
+    return types.map((t: EventType) => {
+      return [ t.name, t.typeId, t.description, t.category.join(', ').trim(), JSON.stringify(t.options) ];
+    })
+  }
+
+  React.useEffect(() => {
+    const sub = context.commandChannel.onResponse('list-event-types')
+      .pipe(
+        filter(m => m.status === 0),
+        map(m => m.payload),
+      )
+      .subscribe(types => setTypes(types));
+    return () => sub.unsubscribe();
+  }, []);
+
+  React.useEffect(() => {
+    context.commandChannel.sendMessage('list-event-types');
+  }, []);
+
+  // TODO paginate or make scrollable, and put Options into collapsible rows
+  return(
+    <Table aria-label="Event Types table" cells={tableColumns} rows={getEventTypes()}>
+      <TableHeader />
+      <TableBody />
+    </Table>
+  );
+
+}

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { filter, map } from 'rxjs/operators';
+import { Pagination } from '@patternfly/react-core';
 import { Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { ServiceContext } from '@app/Shared/Services/Services';
 
@@ -21,6 +22,9 @@ export const EventTypes = (props) => {
   const context = React.useContext(ServiceContext);
 
   const [types, setTypes] = React.useState([]);
+  const [displayedTypes, setDisplayedTypes] = React.useState([]);
+  const [currentPage, setCurrentPage] = React.useState(1);
+  const [perPage, setPerPage] = React.useState(4);
 
   const tableColumns = [
     'Name',
@@ -29,12 +33,6 @@ export const EventTypes = (props) => {
     'Categories',
     'Options',
   ];
-
-  const getEventTypes = () => {
-    return types.map((t: EventType) => {
-      return [ t.name, t.typeId, t.description, t.category.join(', ').trim(), JSON.stringify(t.options) ];
-    })
-  }
 
   React.useEffect(() => {
     const sub = context.commandChannel.onResponse('list-event-types')
@@ -50,12 +48,38 @@ export const EventTypes = (props) => {
     context.commandChannel.sendMessage('list-event-types');
   }, []);
 
+  React.useEffect(() => {
+    const offset = (currentPage - 1) * perPage;
+    const page = types.slice(offset, offset + perPage);
+    setDisplayedTypes(page);
+  }, [currentPage, perPage, types]);
+
+  const getEventTypes = () => {
+    return displayedTypes.map((t: EventType) => {
+      return [ t.name, t.typeId, t.description, t.category.join(', ').trim(), JSON.stringify(t.options) ];
+    })
+  };
+
+  const onCurrentPage = (evt, currentPage) => setCurrentPage(currentPage);
+
+  const onPerPage = (evt, perPage) => setPerPage(perPage);
+
   // TODO paginate or make scrollable, and put Options into collapsible rows
-  return(
+  return(<>
+    <Pagination
+      itemCount={types.length}
+      page={currentPage}
+      perPage={perPage}
+      onSetPage={onCurrentPage}
+      widgetId="event-types-pagination"
+      onPerPageSelect={onPerPage}
+      perPageOptions={[ { title: '4', value: 4 }, { title: '10', value: 10 }, { title: '20', value: 20 } ]}
+      isCompact
+    />
     <Table aria-label="Event Types table" cells={tableColumns} rows={getEventTypes()}>
       <TableHeader />
       <TableBody />
     </Table>
-  );
+  </>);
 
 }

--- a/src/app/Events/Events.tsx
+++ b/src/app/Events/Events.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react'
+import { Card, CardBody, CardHeader, Tabs, Tab, TabsVariant, TabContent, Text, TextVariants } from '@patternfly/react-core';
+import { TargetView } from '@app/TargetView/TargetView';
+import { EventTemplates } from './EventTemplates';
+import { EventTypes } from './EventTypes';
+
+export const Events = (props) => {
+  const [activeTab, setActiveTab] = React.useState(0);
+
+  const handleTabSelect = (evt, idx) => {
+    setActiveTab(idx);
+  }
+
+  return (<>
+    <TargetView pageTitle="Events">
+      <Card>
+        <CardHeader><Text component={TextVariants.h4}>Events</Text></CardHeader>
+        <CardBody>
+          <Tabs isFilled mountOnEnter unmountOnExit activeKey={activeTab} onSelect={handleTabSelect}>
+            <Tab eventKey={0} title="Event Templates">
+              <EventTemplates />
+            </Tab>
+            <Tab eventKey={1} title="Event Types">
+              <EventTypes />
+            </Tab>
+          </Tabs>
+        </CardBody>
+      </Card>
+    </TargetView>
+  </>);
+
+}

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -51,8 +51,8 @@ const dynamicRoutes: IAppRoute[] = [
         exact: true,
         path: '/recordings/create',
         title: 'Create Recording'
-      },
-    ],
+      }
+    ]
   },
   {
     component: Events,

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -35,7 +35,7 @@ const staticRoutes: IAppRoute[] = [
     label: 'Dashboard',
     path: '/',
     title: 'Dashboard'
-  },
+  }
 ];
 
 const dynamicRoutes: IAppRoute[] = [
@@ -59,8 +59,8 @@ const dynamicRoutes: IAppRoute[] = [
     exact: true,
     label: 'Events',
     path: '/events',
-    title: 'Events',
-  },
+    title: 'Events'
+  }
 ];
 
 const flatten = (routes: IAppRoute[]): IAppRoute[] => {
@@ -109,31 +109,30 @@ const PageNotFound = ({ title }: { title: string }) => {
   return <Route component={NotFound} />;
 };
 
-
 const AppRoutes = () => {
   const context = React.useContext(ServiceContext);
   const [authenticated, setAuthenticated] = React.useState(false);
   const [availableRoutes, setAvailableRoutes] = React.useState(staticRoutes);
 
   React.useEffect(() => {
-    const sub = context.commandChannel.isConnected().subscribe(isConnected =>
-        setAvailableRoutes(getAvailableRoutes(isConnected))
-    );
+    const sub = context.commandChannel
+      .isConnected()
+      .subscribe(isConnected => setAvailableRoutes(getAvailableRoutes(isConnected)));
     return () => sub.unsubscribe();
   }, []);
 
   React.useEffect(() => {
-    const sub = context.commandChannel.isReady().pipe(filter(v => !v)).subscribe(() =>
-      setAuthenticated(false)
-    );
+    const sub = context.commandChannel
+      .isReady()
+      .pipe(filter(v => !v))
+      .subscribe(() => setAuthenticated(false));
     return () => sub.unsubscribe();
   }, []);
 
   return (
     <LastLocationProvider>
       <Switch>
-        {
-        authenticated ?
+        {authenticated ? (
           availableRoutes.map(({ path, exact, component, title, isAsync }, idx) => (
             <RouteWithTitleUpdates
               path={path}
@@ -144,12 +143,13 @@ const AppRoutes = () => {
               isAsync={isAsync}
             />
           ))
-          : <Login onLoginSuccess={() => setAuthenticated(true)}/>
-        }
+        ) : (
+          <Login onLoginSuccess={() => setAuthenticated(true)} />
+        )}
         <PageNotFound title="404 Page Not Found" />
       </Switch>
     </LastLocationProvider>
   );
-}
+};
 
 export { AppRoutes, routes, getAvailableRoutes, staticRoutes, dynamicRoutes };

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -12,6 +12,7 @@ import { Login } from '@app/Login/Login';
 import { Dashboard } from '@app/Dashboard/Dashboard';
 import { RecordingList } from '@app/RecordingList/RecordingList';
 import { CreateRecording } from '@app/CreateRecording/CreateRecording';
+import { Events } from '@app/Events/Events';
 
 let routeFocusTimer: number;
 
@@ -43,7 +44,7 @@ const dynamicRoutes: IAppRoute[] = [
     exact: true,
     label: 'Recordings',
     path: '/recordings',
-    title: 'Flight Recordings',
+    title: 'Recordings',
     children: [
       {
         component: CreateRecording,
@@ -52,6 +53,13 @@ const dynamicRoutes: IAppRoute[] = [
         title: 'Create Recording'
       },
     ],
+  },
+  {
+    component: Events,
+    exact: true,
+    label: 'Events',
+    path: '/events',
+    title: 'Events',
   },
 ];
 


### PR DESCRIPTION
This PR adds an initial pass at the Events views outlined in #55 and #56 .

The Templates view is missing the ability to select rows and create recordings from these templates, since the view for creating recordings in general is not yet implemented (see #59).

~~The Types view needs to be made scrollable or to gain pagination, since the number of events is quite long and currently they are all rendered into an extremely large table.~~

![image](https://user-images.githubusercontent.com/3787464/80603905-89943700-8a20-11ea-807b-33eecfc90d0c.png)
![image](https://user-images.githubusercontent.com/3787464/80603950-99138000-8a20-11ea-91ae-f11d3a6a5628.png)
![image](https://user-images.githubusercontent.com/3787464/80603995-aaf52300-8a20-11ea-848a-dc10e7770236.png)

Fixes #55 
Fixes #56