### PR TITLE
"Create Recording" view

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -12,6 +12,7 @@ import {
 } from '@patternfly/react-core';
 import { IAppRoute, staticRoutes, getAvailableRoutes } from '@app/routes';
 import { ServiceContext } from '@app/Shared/Services/Services';
+import { NotificationCenter } from '@app/Notifications/NotificationCenter';
 
 interface IAppLayout {
   children: React.ReactNode;
@@ -89,7 +90,7 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
       Skip to Content
     </SkipToContent>
   );
-  return (
+  return (<>
     <Page
       mainContainerId="primary-app-container"
       header={Header}
@@ -98,7 +99,8 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
       skipToContent={PageSkipToContent}>
       {children}
     </Page>
-  );
+    <NotificationCenter />
+  </>);
 }
 
 export { AppLayout };

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { NavLink } from 'react-router-dom';
+import { NavLink, useRouteMatch } from 'react-router-dom';
 import {
   Nav,
   NavList,
@@ -10,7 +10,7 @@ import {
   PageSidebar,
   SkipToContent
 } from '@patternfly/react-core';
-import { staticRoutes, getAvailableRoutes } from '@app/routes';
+import { IAppRoute, staticRoutes, getAvailableRoutes } from '@app/routes';
 import { ServiceContext } from '@app/Shared/Services/Services';
 
 interface IAppLayout {
@@ -53,11 +53,25 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
     />
   );
 
+  const isActiveRoute = (route: IAppRoute): boolean => {
+    const match = useRouteMatch(route);
+    if (!!match && match.isExact) {
+      return true;
+    } else if (!!route.children) {
+      let childMatch = false;
+      for (const r of route.children) {
+        childMatch = childMatch || isActiveRoute(r);
+      }
+      return childMatch;
+    }
+    return false;
+  };
+
   const Navigation = (
     <Nav id="nav-primary-simple" theme="dark">
       <NavList id="nav-list-simple" variant={NavVariants.default}>
         {availableRoutes.map((route, idx) => route.label && (
-            <NavItem key={`${route.label}-${idx}`} id={`${route.label}-${idx}`}>
+            <NavItem key={`${route.label}-${idx}`} id={`${route.label}-${idx}`} isActive={isActiveRoute(route)}>
               <NavLink exact to={route.path} activeClassName="pf-m-current">{route.label}</NavLink>
             </NavItem>
           ))}

--- a/src/app/BreadcrumbPage/BreadcrumbPage.tsx
+++ b/src/app/BreadcrumbPage/BreadcrumbPage.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { Breadcrumb, BreadcrumbHeading, BreadcrumbItem, PageSection, Stack, StackItem, } from '@patternfly/react-core';
+import { TargetSelect } from '@app/TargetSelect/TargetSelect';
+
+interface BreadcrumbPageProps {
+  children?: { isFilled?: boolean };
+  pageTitle: string;
+  breadcrumbs?: BreadcrumbTrail[];
+}
+
+export interface BreadcrumbTrail {
+  title: string;
+  path: string;
+}
+
+export const BreadcrumbPage = (props: BreadcrumbPageProps) => {
+  return (<>
+    <PageSection>
+      <Breadcrumb>
+        {(props.breadcrumbs || []).map(({ title, path }) => (<BreadcrumbItem to={path}>{title}</BreadcrumbItem>))}
+        <BreadcrumbHeading>{props.pageTitle}</BreadcrumbHeading>
+      </Breadcrumb>
+      <Stack gutter="md">
+        {
+          React.Children.map(props.children, child => (
+            <StackItem isFilled={!!child && child.isFilled}>
+              {child}
+            </StackItem>
+          ))
+        }
+      </Stack>
+    </PageSection>
+  </>);
+
+}

--- a/src/app/CreateRecording/CreateRecording.tsx
+++ b/src/app/CreateRecording/CreateRecording.tsx
@@ -10,11 +10,14 @@ export interface CreateRecordingProps {
   eventSpecifiers?: string[];
 }
 
+export const RecordingNamePattern = /^[a-zA-Z0-9_-]+$/;
+
 export const CreateRecording = (props: CreateRecordingProps) => {
   const context = React.useContext(ServiceContext);
   const history = useHistory();
 
-  const [recordingName, setRecordingName] = React.useState(props.recordingName);
+  const [recordingName, setRecordingName] = React.useState(props.recordingName || '');
+  const [nameValid, setNameValid] = React.useState(false);
   const [continuous, setContinuous] = React.useState(false);
   const [duration, setDuration] = React.useState(30);
   const [durationUnit, setDurationUnit] = React.useState(1);
@@ -43,9 +46,14 @@ export const CreateRecording = (props: CreateRecordingProps) => {
 
   const getEventString = () => !!template ? template : eventSpecifiers.split(/\s+/).filter(Boolean).join(',');
 
+  const handleRecordingNameChange = (name) => {
+    setNameValid(RecordingNamePattern.test(name));
+    setRecordingName(name);
+  };
+
   const handleSubmit = () => {
     const eventString = getEventString();
-    if (!recordingName || !eventString) {
+    if (!nameValid || !eventString) {
       // TODO tell user what's invalid
       // TODO validate eventString properly
       return;
@@ -100,6 +108,7 @@ export const CreateRecording = (props: CreateRecordingProps) => {
               isRequired
               fieldId="recording-name"
               helperText="Please enter a recording name. This will be unique within the target JVM."
+              isValid={nameValid}
             >
               <TextInput
                 value={recordingName}
@@ -107,7 +116,8 @@ export const CreateRecording = (props: CreateRecordingProps) => {
                 type="text"
                 id="recording-name"
                 aria-describedby="recording-name-helper"
-                onChange={setRecordingName}
+                onChange={handleRecordingNameChange}
+                isValid={nameValid}
               />
             </FormGroup>
             <FormGroup

--- a/src/app/CreateRecording/CreateRecording.tsx
+++ b/src/app/CreateRecording/CreateRecording.tsx
@@ -232,12 +232,16 @@ export const CreateRecording = (props: CreateRecordingProps) => {
                 </SplitItem>
                 <SplitItem>
                   <Tooltip
+                    isContentLeftAligned
                     position={TooltipPosition.auto}
                     content={
                       <Text component={TextVariants.p}>
-                        Templates are selected with the syntax <i>template=Foo</i>. Event names and options are specified with the syntax
-                        <i>namespace.EventName:optionName=optionValue</i> &mdash; ex. <i>jdk.SocketRead:enabled=true</i>. Multiple event
-                        option specifiers should be separated by whitespace.
+                        Templates are selected with the syntax <i>template=Foo</i>.<br /><br />
+
+                        Event names and options are specified with the syntax <i>ns.Event:option=Value</i>
+                        &mdash; ex. <i>jdk.SocketRead:enabled=true</i>.<br /><br />
+
+                      Multiple event option specifiers should be separated by whitespace.
                       </Text>
                     }
                   >

--- a/src/app/CreateRecording/CreateRecording.tsx
+++ b/src/app/CreateRecording/CreateRecording.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import { filter, first, map } from 'rxjs/operators';
-import { ActionGroup, Breadcrumb, BreadcrumbHeading, BreadcrumbItem, Button, Card, CardBody, CardHeader, Checkbox, Form, FormGroup, FormSelect, FormSelectOption, FormSelectOptionGroup, TextArea, TextInput, PageSection, Split, SplitItem, Text, TextVariants, Title } from '@patternfly/react-core';
+import { ActionGroup, Breadcrumb, BreadcrumbHeading, BreadcrumbItem, Button, Card, CardBody, CardHeader, Checkbox, Form, FormGroup, FormSelect, FormSelectOption, FormSelectOptionGroup, TextArea, TextInput, PageSection, Split, SplitItem, Text, TextVariants, Title, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { ServiceContext } from '@app/Shared/Services/Services';
 
 export interface CreateRecordingProps {
@@ -193,6 +194,7 @@ export const CreateRecording = (props: CreateRecordingProps) => {
               isRequired
               fieldId="recording-events"
               isValid={eventsValid}
+              helperText="Select a template from the dropdown, or enter a template name or event specifier string in the text area."
             >
               <Split gutter="md">
                 <SplitItem>
@@ -208,6 +210,20 @@ export const CreateRecording = (props: CreateRecordingProps) => {
                       }
                     </FormSelectOptionGroup>
                   </FormSelect>
+                </SplitItem>
+                <SplitItem>
+                  <Tooltip
+                    position={TooltipPosition.auto}
+                    content={
+                      <Text component={TextVariants.p}>
+                        Templates are selected with the syntax <i>template=Foo</i>. Event names and options are specified with the syntax
+                        <i>namespace.EventName:optionName=optionValue</i> &mdash; ex. <i>jdk.SocketRead:enabled=true</i>. Multiple event
+                        option specifiers should be separated by whitespace.
+                      </Text>
+                    }
+                  >
+                    <OutlinedQuestionCircleIcon />
+                  </Tooltip>
                 </SplitItem>
                 <SplitItem isFilled>
                   <TextArea value={getEventSpecifiers()} onChange={handleEventSpecifiersChange} aria-label="Custom Event Specifiers Area" isValid={eventsValid} />

--- a/src/app/CreateRecording/CreateRecording.tsx
+++ b/src/app/CreateRecording/CreateRecording.tsx
@@ -1,14 +1,181 @@
 import * as React from 'react';
-import { Card, CardBody, CardHeader, PageSection, Text, TextVariants, Title } from '@patternfly/react-core';
+import { useHistory } from 'react-router-dom';
+import { filter, first, map } from 'rxjs/operators';
+import { ActionGroup, Button, Card, CardBody, CardHeader, Checkbox, Form, FormGroup, FormSelect, FormSelectOption, FormSelectOptionGroup, TextArea, TextInput, PageSection, Split, SplitItem, Text, TextVariants, Title } from '@patternfly/react-core';
+import { ServiceContext } from '@app/Shared/Services/Services';
 
-export const CreateRecording = (props) => {
+export interface CreateRecordingProps {
+  recordingName?: string;
+  template?: string;
+  eventSpecifiers?: string[];
+}
+
+export const CreateRecording = (props: CreateRecordingProps) => {
+  const context = React.useContext(ServiceContext);
+  const history = useHistory();
+
+  const [recordingName, setRecordingName] = React.useState(props.recordingName);
+  const [continuous, setContinuous] = React.useState(false);
+  const [duration, setDuration] = React.useState(30);
+  const [durationUnit, setDurationUnit] = React.useState(1);
+  const [templates, setTemplates] = React.useState([]);
+  const [template, setTemplate] = React.useState('');
+  const [eventSpecifiers, setEventSpecifiers] = React.useState('');
+
+  const handleContinuousChange = (checked, evt) => {
+    setContinuous(evt.target.checked);
+  };
+
+  const handleDurationChange = (evt) => {
+    setDuration(Number(evt));
+  };
+
+  const handleDurationUnitChange = (evt) => {
+    setDurationUnit(Number(evt));
+  };
+
+  const handleEventSpecifiersChange = (evt) => {
+    setTemplate('');
+    setEventSpecifiers(evt);
+  };
+
+  const getEventSpecifiers = () => !!template ? template : eventSpecifiers;
+
+  const getEventString = () => !!template ? template : eventSpecifiers.split(/\s+/).filter(Boolean).join(',');
+
+  const handleSubmit = () => {
+    const eventString = getEventString();
+    if (!recordingName || !eventString) {
+      // TODO tell user what's invalid
+      // TODO validate eventString properly
+      return;
+    }
+    const command = continuous ? 'start' : 'dump';
+    const id = context.commandChannel.createMessageId();
+    context.commandChannel.onResponse(command).pipe(
+      filter(m => m.id === id),
+      filter(m => m.status === 0), // TODO inform the user if the request fails
+      first(),
+      )
+      .subscribe(() => history.push('/recordings'));
+    const args = [recordingName];
+    if (!continuous) {
+      const eventDuration = continuous ? 0 : duration * durationUnit;
+      args.push(String(eventDuration));
+    }
+    args.push(eventString);
+    context.commandChannel.sendMessage(command, args, id);
+  };
+
+  React.useEffect(() => {
+    const sub = context.commandChannel.onResponse('list-event-templates')
+      .pipe(
+        filter(m => m.status === 0),
+        map(m => m.payload),
+      )
+      .subscribe(m => setTemplates(m));
+    return () => sub.unsubscribe();
+  }, []);
+
+  React.useEffect(() => {
+    context.commandChannel.sendMessage('list-event-templates');
+  }, []);
 
   return (
     <PageSection>
       <Title size="lg">Create Recording</Title>
       <Card>
         <CardBody>
-          <Text component={TextVariants.p}>Create Recording View</Text>
+          <Text component={TextVariants.p}>Create Flight Recording</Text>
+          <Text component={TextVariants.small}>
+            JDK Flight Recordings are compact records of events which have occurred within the target JVM.
+            Many event types are built-in to the JVM itself, while others are user-defined.
+          </Text>
+          <Form isHorizontal>
+            <FormGroup
+              label="Name"
+              isRequired
+              fieldId="recording-name"
+              helperText="Please enter a recording name. This will be unique within the target JVM."
+            >
+              <TextInput
+                value={recordingName}
+                isRequired
+                type="text"
+                id="recording-name"
+                aria-describedby="recording-name-helper"
+                onChange={setRecordingName}
+              />
+            </FormGroup>
+            <FormGroup
+              label="Duration"
+              isRequired
+              fieldId="recording-duration"
+            >
+              <Checkbox
+                label="Continuous"
+                isChecked={continuous}
+                onChange={handleContinuousChange}
+                aria-label="Continuous checkbox"
+                id="recording-continuous"
+                name="recording-continuous"
+              />
+              <Split gutter="md">
+                <SplitItem isFilled>
+                  <TextInput
+                    value={duration}
+                    isRequired
+                    type="number"
+                    id="recording-duration"
+                    aria-describedby="recording-duration-helper"
+                    onChange={handleDurationChange}
+                    isDisabled={continuous}
+                  />
+                </SplitItem>
+                <SplitItem>
+                  <FormSelect
+                    value={durationUnit}
+                    onChange={handleDurationUnitChange}
+                    aria-label="Duration Units Input"
+                    isDisabled={continuous}
+                  >
+                    <FormSelectOption key="1" value="1" label="Seconds" />
+                    <FormSelectOption key="2" value={60} label="Minutes" />
+                    <FormSelectOption key="3" value={60*60}label="Hours" />
+                  </FormSelect>
+                </SplitItem>
+              </Split>
+            </FormGroup>
+            <FormGroup
+              label="Events"
+              isRequired
+              fieldId="recording-events"
+            >
+              <Split gutter="md">
+                <SplitItem>
+                  <FormSelect
+                    value={template}
+                    onChange={setTemplate}
+                    aria-label="Event Template Input"
+                  >
+                    <FormSelectOption key="0" value="" label="Custom Event Definition" />
+                    <FormSelectOptionGroup key="1" label="Remote Templates">
+                      {
+                        templates.map(({ name }: { name: string }, idx: number) => (<FormSelectOption key={idx+2} value={`template=${name}`} label={name} />))
+                      }
+                    </FormSelectOptionGroup>
+                  </FormSelect>
+                </SplitItem>
+                <SplitItem isFilled>
+                  <TextArea value={getEventSpecifiers()} onChange={handleEventSpecifiersChange} aria-label="Custom Event Specifiers Area" />
+                </SplitItem>
+              </Split>
+            </FormGroup>
+            <ActionGroup>
+              <Button variant="primary" onClick={handleSubmit}>Create</Button>
+              <Button variant="secondary" onClick={history.goBack}>Cancel</Button>
+            </ActionGroup>
+          </Form>
         </CardBody>
       </Card>
     </PageSection>

--- a/src/app/CreateRecording/CreateRecording.tsx
+++ b/src/app/CreateRecording/CreateRecording.tsx
@@ -143,6 +143,7 @@ export const CreateRecording = (props: CreateRecordingProps) => {
                     aria-describedby="recording-duration-helper"
                     onChange={handleDurationChange}
                     isDisabled={continuous}
+                    min="0"
                   />
                 </SplitItem>
                 <SplitItem>

--- a/src/app/CreateRecording/CreateRecording.tsx
+++ b/src/app/CreateRecording/CreateRecording.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import { filter, first, map } from 'rxjs/operators';
-import { ActionGroup, Button, Card, CardBody, CardHeader, Checkbox, Form, FormGroup, FormSelect, FormSelectOption, FormSelectOptionGroup, TextArea, TextInput, PageSection, Split, SplitItem, Text, TextVariants, Title } from '@patternfly/react-core';
+import { ActionGroup, Breadcrumb, BreadcrumbHeading, BreadcrumbItem, Button, Card, CardBody, CardHeader, Checkbox, Form, FormGroup, FormSelect, FormSelectOption, FormSelectOptionGroup, TextArea, TextInput, PageSection, Split, SplitItem, Text, TextVariants, Title } from '@patternfly/react-core';
 import { ServiceContext } from '@app/Shared/Services/Services';
 
 export interface CreateRecordingProps {
@@ -83,7 +83,10 @@ export const CreateRecording = (props: CreateRecordingProps) => {
 
   return (
     <PageSection>
-      <Title size="lg">Create Recording</Title>
+      <Breadcrumb>
+        <BreadcrumbItem to="/recordings">Recordings</BreadcrumbItem>
+        <BreadcrumbHeading>Create</BreadcrumbHeading>
+      </Breadcrumb>
       <Card>
         <CardBody>
           <Text component={TextVariants.p}>Create Flight Recording</Text>

--- a/src/app/CreateRecording/CreateRecording.tsx
+++ b/src/app/CreateRecording/CreateRecording.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { Card, CardBody, CardHeader, PageSection, Text, TextVariants, Title } from '@patternfly/react-core';
+
+export const CreateRecording = (props) => {
+
+  return (
+    <PageSection>
+      <Title size="lg">Create Recording</Title>
+      <Card>
+        <CardBody>
+          <Text component={TextVariants.p}>Create Recording View</Text>
+        </CardBody>
+      </Card>
+    </PageSection>
+  );
+
+};

--- a/src/app/Notifications/NotificationCenter.tsx
+++ b/src/app/Notifications/NotificationCenter.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { Alert, AlertActionCloseButton, AlertGroup, AlertVariant, Text, TextVariants } from '@patternfly/react-core';
+import { Notification, NotificationsContext } from './Notifications';
+
+export const NotificationCenter = (props) => {
+  const context = React.useContext(NotificationsContext);
+
+  const [notifications, setNotifications] = React.useState([] as Notification[]);
+
+  const removeNotificationByKey = (notifications, key) => {
+    const idx = notifications.findIndex(n => n.key === key);
+    if (idx < 0) {
+      return notifications;
+    }
+    const before = notifications.slice(0, idx);
+    const after = notifications.slice(idx + 1, notifications.length);
+    return before.concat(after);
+  };
+
+  const addNotification = (notification: Notification) => {
+    setNotifications([...notifications, notification]);
+    if (notification.timeout > 0) {
+      setTimeout(() => setNotifications(removeNotificationByKey(notifications, notification.key)), notification.timeout);
+    }
+  };
+
+  React.useEffect(() => {
+    const sub = context.watch().subscribe(notification => addNotification(notification));
+    return () => sub.unsubscribe();
+  });
+
+  return (<>
+    <AlertGroup isToast>
+    {
+      notifications.map(({key, title, message, variant}) => (
+        <Alert
+          isLiveRegion
+          variant={AlertVariant[variant]}
+          title={title}
+          key={key}
+          action={
+            <AlertActionCloseButton
+              title={title}
+              variantLabel={`${variant} alert`}
+              onClose={() => setNotifications(removeNotificationByKey(notifications, key))}
+            />
+          }
+        >
+          <Text component={TextVariants.p}>{message}</Text>
+        </Alert>
+      ))
+    }
+    </AlertGroup>
+  </>);
+
+};

--- a/src/app/Notifications/Notifications.tsx
+++ b/src/app/Notifications/Notifications.tsx
@@ -49,6 +49,8 @@ class Notifications {
 
 }
 
-const NotificationsContext = React.createContext(new Notifications());
+const NotificationsInstance = new Notifications();
 
-export { Notification, DefaultNotificationTimeout, Notifications, NotificationsContext };
+const NotificationsContext = React.createContext(NotificationsInstance);
+
+export { Notification, DefaultNotificationTimeout, Notifications, NotificationsContext, NotificationsInstance };

--- a/src/app/Notifications/Notifications.tsx
+++ b/src/app/Notifications/Notifications.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { Observable, Subject } from 'rxjs';
+import { AlertVariant } from '@patternfly/react-core';
+import { nanoid } from 'nanoid';
+
+interface Notification {
+  key?: string;
+  title: string;
+  message?: string;
+  variant: AlertVariant;
+  timeout?: number;
+}
+
+const DefaultNotificationTimeout = 15_000;
+
+class Notifications {
+
+  private readonly notifications = new Subject<Notification>();
+
+  notify(notification: Notification): void {
+    if (!notification.key) {
+      notification.key = nanoid();
+    }
+    if (notification.timeout == undefined || notification.timeout < 0) {
+      notification.timeout = DefaultNotificationTimeout;
+    }
+    this.notifications.next(notification);
+  }
+
+  success(title: string, message?: string, timeout?: number): void {
+    this.notify({ title, message, timeout, variant: AlertVariant.success });
+  }
+
+  info(title: string, message?: string, timeout?: number): void {
+    this.notify({ title, message, timeout, variant: AlertVariant.info });
+  }
+
+  warning(title: string, message?: string, timeout?: number): void {
+    this.notify({ title, message, timeout, variant: AlertVariant.warning });
+  }
+
+  danger(title: string, message?: string, timeout?: number): void {
+    this.notify({ title, message, timeout, variant: AlertVariant.danger });
+  }
+
+  watch(): Observable<Notification> {
+    return this.notifications.asObservable();
+  }
+
+}
+
+const NotificationsContext = React.createContext(new Notifications());
+
+export { Notification, DefaultNotificationTimeout, Notifications, NotificationsContext };

--- a/src/app/RecordingList/RecordingList.tsx
+++ b/src/app/RecordingList/RecordingList.tsx
@@ -47,7 +47,7 @@ export const RecordingList = (props) => {
     return recordings.map((recording: Recording) => [
       recording.name,
       new Date(recording.startTime).toISOString(),
-      `${recording.duration / 1000} s`,
+      recording.duration === 0 ? 'Continuous' : `${recording.duration / 1000} s`,
       recording.downloadUrl,
       recording.reportUrl,
       recording.state,

--- a/src/app/RecordingList/RecordingList.tsx
+++ b/src/app/RecordingList/RecordingList.tsx
@@ -75,7 +75,7 @@ export const RecordingList = (props) => {
   }, []);
 
   return (
-    <TargetView pageTitle="Flight Recordings">
+    <TargetView pageTitle="Recordings">
       <Card>
         <CardHeader><Text component={TextVariants.h4}>Active Recordings</Text></CardHeader>
         <CardBody>

--- a/src/app/RecordingList/RecordingList.tsx
+++ b/src/app/RecordingList/RecordingList.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import { useHistory, useRouteMatch } from 'react-router-dom';
 import { filter, map } from 'rxjs/operators';
-import { Card, CardBody, CardHeader, PageSection, Text, TextVariants, Title } from '@patternfly/react-core';
+import { Button, Card, CardBody, CardHeader, PageSection, Text, TextVariants, Title } from '@patternfly/react-core';
 import { Table, TableHeader, TableBody, textCenter } from '@patternfly/react-table';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { TargetView } from '@app/TargetView/TargetView';
@@ -28,8 +29,10 @@ enum RecordingState {
 
 export const RecordingList = (props) => {
   const context = React.useContext(ServiceContext);
+  const routerHistory = useHistory();
 
   const [recordings, setRecordings] = React.useState([]);
+  const { path, url } = useRouteMatch();
 
   const tableColumns: string[] = [
     'Name',
@@ -49,6 +52,10 @@ export const RecordingList = (props) => {
       recording.reportUrl,
       recording.state,
     ]);
+  };
+
+  const handleCreateRecording = () => {
+    routerHistory.push(`${url}/create`);
   };
 
   React.useEffect(() => {
@@ -72,6 +79,7 @@ export const RecordingList = (props) => {
       <Card>
         <CardHeader><Text component={TextVariants.h4}>Active Recordings</Text></CardHeader>
         <CardBody>
+          <Button onClick={handleCreateRecording} >Create</Button>
           <Table aria-label="Recordings Table" cells={tableColumns} rows={getRecordingRows()}>
             <TableHeader />
             <TableBody />

--- a/src/app/Shared/Services/CommandChannel.service.tsx
+++ b/src/app/Shared/Services/CommandChannel.service.tsx
@@ -133,7 +133,7 @@ export class CommandChannel {
     }
   }
 
-  sendMessage(command: string, args: string[] = [], id: string = nanoid()): Observable<string> {
+  sendMessage(command: string, args: string[] = [], id: string = this.createMessageId()): Observable<string> {
     const subj = new Subject<string>();
     this.ready.pipe(
       first(),
@@ -151,6 +151,10 @@ export class CommandChannel {
     return subj.asObservable();
   }
 
+  createMessageId(): string {
+    return nanoid();
+  }
+
   onResponse(command: string): Observable<ResponseMessage<any>> {
     return this.messages
       .asObservable()
@@ -161,11 +165,13 @@ export class CommandChannel {
 }
 
 export interface CommandMessage {
+  id: string;
   command: string;
   args?: string[];
 }
 
 export interface ResponseMessage<T> {
+  id?: string;
   status: number;
   commandName: string;
   payload: T;

--- a/src/app/Shared/Services/CommandChannel.service.tsx
+++ b/src/app/Shared/Services/CommandChannel.service.tsx
@@ -2,6 +2,7 @@ import { from, Subject, BehaviorSubject, Observable, ReplaySubject, combineLates
 import { fromFetch } from 'rxjs/fetch';
 import { concatMap, distinctUntilChanged, filter, first, map, tap } from 'rxjs/operators';
 import { ApiService } from './Api.service';
+import { Notifications } from '@app/Notifications/Notifications';
 import { nanoid } from 'nanoid';
 
 export class CommandChannel {
@@ -16,26 +17,26 @@ export class CommandChannel {
   private readonly grafanaDatasourceUrlSubject = new ReplaySubject<string>(1);
   private pingTimer: number = -1;
 
-  constructor(apiSvc: ApiService) {
+  constructor(apiSvc: ApiService, private readonly notifications: Notifications) {
     this.apiSvc = apiSvc;
 
     fromFetch(`${this.apiSvc.authority}/clienturl`)
       .pipe(concatMap(resp => from(resp.json())))
       .subscribe(
         (url: any) => this.clientUrlSubject.next(url.clientUrl),
-        (err: any) => console.error('Client URL configuration', err) // TODO add toast notification
+        (err: any) => this.logError('Client URL configuration', err)
       );
 
     fromFetch(`${this.apiSvc.authority}/grafana_datasource_url`)
       .pipe(concatMap(resp => from(resp.json())))
       .subscribe(
         (url: any) => this.grafanaDatasourceUrlSubject.next(url.grafanaDatasourceUrl),
-        (err: any) => console.error('Grafana Datasource configuration', err) // TODO add toast notification
+        (err: any) => this.logError('Grafana Datasource configuration', err)
       );
 
     this.onResponse('disconnect').pipe(
       filter(msg => msg.status !== 0),
-    ).subscribe(msg => console.warn('Command failure', JSON.stringify(msg)));
+    ).subscribe(msg => this.logError('Command failure', msg));
 
     this.onResponse('list-saved').pipe(
       first(),
@@ -88,12 +89,12 @@ export class CommandChannel {
           }
         });
 
-        this.ws.addEventListener('error', (evt: Event) => console.error('WebSocket error', evt));
+        this.ws.addEventListener('error', (evt: Event) => this.logError('WebSocket error', evt));
 
         this.ws.addEventListener('close', () => {
           this.ready.next(false);
           window.clearInterval(this.pingTimer);
-          console.log('WebSocket connection lost');
+          this.notifications.info('WebSocket connection lost');
         });
 
         this.ws.addEventListener('open', () => {
@@ -142,9 +143,9 @@ export class CommandChannel {
       if (!!i && this.ws) {
         this.ws.send(JSON.stringify({ id, command, args }));
       } else if (this.ws) {
-        console.warn('Attempted to send message when command channel was not ready', { id, command, args });
+        this.logError('Attempted to send message when command channel was not ready', { id, command, args });
       } else {
-        console.error('Attempted to send message when command channel was not initialized', { id, command, args });
+        this.logError('Attempted to send message when command channel was not initialized', { id, command, args });
       }
       subj.next(i);
     });
@@ -161,6 +162,11 @@ export class CommandChannel {
       .pipe(
         filter(m => m.commandName === command)
       );
+  }
+
+  private logError(title: string, err: any): void {
+    console.error(err);
+    this.notifications.danger(title, JSON.stringify(err));
   }
 }
 

--- a/src/app/Shared/Services/Services.tsx
+++ b/src/app/Shared/Services/Services.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { ApiService } from './Api.service';
 import { CommandChannel } from './CommandChannel.service';
+import { NotificationsInstance } from '@app/Notifications/Notifications';
 
 interface Services {
   api: ApiService;
@@ -8,7 +9,7 @@ interface Services {
 }
 
 const api = new ApiService();
-const commandChannel = new CommandChannel(api);
+const commandChannel = new CommandChannel(api, NotificationsInstance);
 
 const defaultServices: Services = { api, commandChannel };
 

--- a/src/app/TargetView/TargetView.tsx
+++ b/src/app/TargetView/TargetView.tsx
@@ -1,20 +1,27 @@
 import * as React from 'react';
-import { PageSection, Stack, StackItem, Title } from '@patternfly/react-core';
+import { Breadcrumb, BreadcrumbHeading, BreadcrumbItem, PageSection, Stack, StackItem, } from '@patternfly/react-core';
 import { TargetSelect } from '@app/TargetSelect/TargetSelect';
 
 interface TargetViewProps {
   children?: any;
   pageTitle: string;
-  targetSelectWidth?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
   compactSelect?: boolean;
   allowDisconnect?: boolean;
+  breadcrumbs?: BreadcrumbTrail[];
+}
+
+export interface BreadcrumbTrail {
+  title: string;
+  path: string;
 }
 
 export const TargetView = (props: TargetViewProps) => {
-
   return (<>
     <PageSection>
-      <Title size="lg">{props.pageTitle}</Title>
+      <Breadcrumb>
+        {(props.breadcrumbs || []).map(({ title, path }) => (<BreadcrumbItem to={path}>{title}</BreadcrumbItem>))}
+        <BreadcrumbHeading>{props.pageTitle}</BreadcrumbHeading>
+      </Breadcrumb>
       <Stack gutter="md">
         <StackItem>
           <TargetSelect isCompact={props.compactSelect == null ? true : props.compactSelect} allowDisconnect={props.allowDisconnect || false} />

--- a/src/app/TargetView/TargetView.tsx
+++ b/src/app/TargetView/TargetView.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { Breadcrumb, BreadcrumbHeading, BreadcrumbItem, PageSection, Stack, StackItem, } from '@patternfly/react-core';
 import { TargetSelect } from '@app/TargetSelect/TargetSelect';
+import { BreadcrumbPage, BreadcrumbTrail } from '@app/BreadcrumbPage/BreadcrumbPage';
 
 interface TargetViewProps {
   children?: any;
@@ -10,31 +10,12 @@ interface TargetViewProps {
   breadcrumbs?: BreadcrumbTrail[];
 }
 
-export interface BreadcrumbTrail {
-  title: string;
-  path: string;
-}
-
 export const TargetView = (props: TargetViewProps) => {
   return (<>
-    <PageSection>
-      <Breadcrumb>
-        {(props.breadcrumbs || []).map(({ title, path }) => (<BreadcrumbItem to={path}>{title}</BreadcrumbItem>))}
-        <BreadcrumbHeading>{props.pageTitle}</BreadcrumbHeading>
-      </Breadcrumb>
-      <Stack gutter="md">
-        <StackItem>
-          <TargetSelect isCompact={props.compactSelect == null ? true : props.compactSelect} allowDisconnect={props.allowDisconnect || false} />
-        </StackItem>
-        {
-          React.Children.map(props.children, child => (
-            <StackItem isFilled>
-              {child}
-            </StackItem>
-          ))
-        }
-      </Stack>
-    </PageSection>
+    <BreadcrumbPage pageTitle={props.pageTitle} breadcrumbs={props.breadcrumbs}>
+      <TargetSelect isCompact={props.compactSelect == null ? true : props.compactSelect} allowDisconnect={props.allowDisconnect || false} isFilled={false} />
+      { props.children }
+    </BreadcrumbPage>
   </>);
 
 }

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -11,6 +11,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { Login } from '@app/Login/Login';
 import { Dashboard } from '@app/Dashboard/Dashboard';
 import { RecordingList } from '@app/RecordingList/RecordingList';
+import { CreateRecording } from '@app/CreateRecording/CreateRecording';
 
 let routeFocusTimer: number;
 
@@ -43,6 +44,12 @@ const dynamicRoutes: IAppRoute[] = [
     path: '/recordings',
     title: 'Flight Recordings'
   },
+  {
+    component: CreateRecording,
+    exact: true,
+    path: '/recordings/create',
+    title: 'Create Recording'
+  },
 ];
 
 const getAvailableRoutes = isConnected => isConnected ? staticRoutes.concat(dynamicRoutes) : staticRoutes;
@@ -64,7 +71,7 @@ const useA11yRouteChange = (isAsync: boolean) => {
   }, [isAsync, lastNavigation]);
 };
 
-const RouteWithTitleUpdates = ({ component: Component, isAsync = false, title, ...rest }: IAppRoute) => {
+const RouteWithTitleUpdates = ({ component: Component, isAsync = false, path, title, ...rest }: IAppRoute) => {
   useA11yRouteChange(isAsync);
   useDocumentTitle(title);
 
@@ -72,7 +79,7 @@ const RouteWithTitleUpdates = ({ component: Component, isAsync = false, title, .
     return <Component {...rest} {...routeProps} />;
   }
 
-  return <Route render={routeWithTitle} />;
+  return <Route render={routeWithTitle} path={path} />;
 };
 
 const PageNotFound = ({ title }: { title: string }) => {

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -24,6 +24,7 @@ export interface IAppRoute {
   path: string;
   title: string;
   isAsync?: boolean;
+  children?: IAppRoute[];
 }
 
 const staticRoutes: IAppRoute[] = [
@@ -42,17 +43,30 @@ const dynamicRoutes: IAppRoute[] = [
     exact: true,
     label: 'Recordings',
     path: '/recordings',
-    title: 'Flight Recordings'
-  },
-  {
-    component: CreateRecording,
-    exact: true,
-    path: '/recordings/create',
-    title: 'Create Recording'
+    title: 'Flight Recordings',
+    children: [
+      {
+        component: CreateRecording,
+        exact: true,
+        path: '/recordings/create',
+        title: 'Create Recording'
+      },
+    ],
   },
 ];
 
-const getAvailableRoutes = isConnected => isConnected ? staticRoutes.concat(dynamicRoutes) : staticRoutes;
+const flatten = (routes: IAppRoute[]): IAppRoute[] => {
+  const ret: IAppRoute[] = [];
+  for (const r of routes) {
+    ret.push(r);
+    if (r.children) {
+      ret.push(...flatten(r.children));
+    }
+  }
+  return ret;
+};
+
+const getAvailableRoutes = isConnected => flatten(isConnected ? staticRoutes.concat(dynamicRoutes) : staticRoutes);
 
 const routes: IAppRoute[] = staticRoutes.concat(dynamicRoutes);
 


### PR DESCRIPTION
This PR adds an initial pass at #58 and an associated minor enhancement to #57 .

A new "Create Recording" view is added, which is routed as a child of the Recordings List view. The Recordings List gains a
"Create" toolbar button which links to the new view.

The new view is just a form with a bit of logic to determine what command name and arguments to use for the recording
request sent to ContainerJFR. When the request is successfully submitted, the view routes back to the Recordings List.
If the user cancels out of the view then they are returned to their previous location - currently this can only be the
Recordings List, but other links are possible in the future.

Not yet handled:
~~1. input validation~~
~~2. any system for notifying users of what went wrong if the request fails (invalid input, duplicate recording name, etc.)~~
~~3. the app Nav bar will not indicate any location when the user is in the Create Recording view. It should probably highlight the parent path as active~~
~~4. breadcrumbs at the top of the view~~

![image](https://user-images.githubusercontent.com/3787464/80604181-ee4f9180-8a20-11ea-895a-3e8f466d7057.png)
![image](https://user-images.githubusercontent.com/3787464/80612163-1c39d380-8a2b-11ea-91fa-2622a8938d42.png)
![image](https://user-images.githubusercontent.com/3787464/80612206-2c51b300-8a2b-11ea-8a69-8125590f4934.png)

![image](https://user-images.githubusercontent.com/3787464/80604287-13440480-8a21-11ea-83a0-986bab35c54f.png)
