### PR TITLE
Recording List overhaul as Data List

### DIFF
--- a/src/app/RecordingList/RecordingList.tsx
+++ b/src/app/RecordingList/RecordingList.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { useHistory, useRouteMatch } from 'react-router-dom';
 import { filter, map } from 'rxjs/operators';
-import { Button, Card, CardBody, CardHeader, PageSection, Text, TextVariants, Title } from '@patternfly/react-core';
-import { Table, TableHeader, TableBody, textCenter } from '@patternfly/react-table';
+import { Button, Card, CardBody, CardHeader, DataList, DataListItem, DataListItemRow, DataListItemCells, DataListCell, PageSection, Text, TextVariants, Title } from '@patternfly/react-core';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { TargetView } from '@app/TargetView/TargetView';
 
@@ -74,16 +73,74 @@ export const RecordingList = (props) => {
     return () => clearInterval(id);
   }, []);
 
+  const RecordingRow = (props) => {
+    return (
+      <DataListItemRow>
+        <DataListItemCells
+          dataListCells={[
+            <DataListCell key={`table-row-${props.index}-1`}>
+              {props.recording.name}
+            </DataListCell>,
+            <DataListCell key={`table-row-${props.index}-2`}>
+              <ISOTime timeStr={props.recording.startTime} />
+            </DataListCell>,
+            <DataListCell key={`table-row-${props.index}-3`}>
+              <RecordingDuration duration={props.recording.duration} />
+            </DataListCell>,
+            <DataListCell key={`table-row-${props.index}-4`}>
+              <Link download url={props.recording.downloadUrl} />
+            </DataListCell>,
+            // TODO make row expandable and render report in collapsed iframe
+            <DataListCell key={`table-row-${props.index}-5`}>
+              <Link url={props.recording.reportUrl} />
+            </DataListCell>,
+            <DataListCell key={`table-row-${props.index}-6`}>
+              {props.recording.state}
+            </DataListCell>
+          ]}
+        />
+      </DataListItemRow>
+    );
+  };
+
+  const ISOTime = (props) => {
+    const fmt = new Date(props.timeStr).toISOString();
+    return (<span>{fmt}</span>);
+  };
+
+  const RecordingDuration = (props) => {
+    const str = props.duration === 0 ? 'Continuous' : `${props.duration / 1000}s`
+    return (<span>{str}</span>);
+  };
+
+  const Link = (props) => {
+    return (<a href={props.url} download={!!props.download} target="_blank">{props.display || props.url}</a>);
+  };
+
   return (
     <TargetView pageTitle="Recordings">
       <Card>
         <CardHeader><Text component={TextVariants.h4}>Active Recordings</Text></CardHeader>
         <CardBody>
-          <Button onClick={handleCreateRecording} >Create</Button>
-          <Table aria-label="Recordings Table" cells={tableColumns} rows={getRecordingRows()}>
-            <TableHeader />
-            <TableBody />
-          </Table>
+          <Button onClick={handleCreateRecording}>Create</Button>
+          <DataList aria-label="Recording List">
+            <DataListItem aria-labelledby="table-header-1">
+              <DataListItemRow>
+                <DataListItemCells
+                  dataListCells={tableColumns.map((key , idx) => (
+                    <DataListCell key={key}>
+                      <span id={`table-header-${idx}`}>{key}</span>
+                    </DataListCell>
+                  ))}
+                />
+              </DataListItemRow>
+            </DataListItem>
+            <DataListItem aria-labelledby="table-row-1-1">
+            {
+              recordings.map((r, idx) => <RecordingRow recording={r} index={idx}/>)
+            }
+            </DataListItem>
+          </DataList>
         </CardBody>
       </Card>
     </TargetView>

--- a/src/app/RecordingList/RecordingList.tsx
+++ b/src/app/RecordingList/RecordingList.tsx
@@ -120,7 +120,7 @@ export const RecordingList = (props) => {
               <RecordingDuration duration={props.recording.duration} />
             </DataListCell>,
             <DataListCell key={`table-row-${props.index}-4`}>
-              <Link download url={props.recording.downloadUrl} />
+              <Link url={`${props.recording.downloadUrl}.jfr`} />
             </DataListCell>,
             // TODO make row expandable and render report in collapsed iframe
             <DataListCell key={`table-row-${props.index}-5`}>
@@ -146,7 +146,7 @@ export const RecordingList = (props) => {
   };
 
   const Link = (props) => {
-    return (<a href={props.url} download={!!props.download} target="_blank">{props.display || props.url}</a>);
+    return (<a href={props.url} target="_blank">{props.display || props.url}</a>);
   };
 
   const RecordingsToolbar = (props) => {

--- a/src/app/RecordingList/RecordingList.tsx
+++ b/src/app/RecordingList/RecordingList.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useHistory, useRouteMatch } from 'react-router-dom';
 import { filter, map } from 'rxjs/operators';
-import { Button, Card, CardBody, CardHeader, DataList, DataListCheck, DataListItem, DataListItemRow, DataListItemCells, DataListCell, PageSection, Text, TextVariants, Title } from '@patternfly/react-core';
+import { Button, Card, CardBody, CardHeader, DataList, DataListCheck, DataListItem, DataListItemRow, DataListItemCells, DataListCell, PageSection, Text, TextVariants, Title, Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { TargetView } from '@app/TargetView/TargetView';
 
@@ -66,6 +66,16 @@ export const RecordingList = (props) => {
       const after = checkedIndices.slice(idx + 1, checkedIndices.length);
       setCheckedIndices([...before, ...after]);
     }
+  };
+
+  const handleDeleteRecordings = () => {
+    recordings.forEach((r: Recording, idx) => {
+      if (checkedIndices.includes(idx)) {
+        handleRowCheck(false, idx);
+        context.commandChannel.sendMessage('delete', [ r.name ]);
+      }
+    });
+    context.commandChannel.sendMessage('list');
   };
 
   React.useEffect(() => {
@@ -134,7 +144,18 @@ export const RecordingList = (props) => {
       <Card>
         <CardHeader><Text component={TextVariants.h4}>Active Recordings</Text></CardHeader>
         <CardBody>
-          <Button onClick={handleCreateRecording}>Create</Button>
+          <Toolbar>
+            <ToolbarGroup>
+              <ToolbarItem>
+                <Button onClick={handleCreateRecording}>Create</Button>
+              </ToolbarItem>
+            </ToolbarGroup>
+            <ToolbarGroup>
+              <ToolbarItem>
+                <Button variant="danger" onClick={handleDeleteRecordings}>Delete</Button>
+              </ToolbarItem>
+            </ToolbarGroup>
+          </Toolbar>
           <DataList aria-label="Recording List">
             <DataListItem aria-labelledby="table-header-1">
               <DataListItemRow>

--- a/src/app/RecordingList/RecordingList.tsx
+++ b/src/app/RecordingList/RecordingList.tsx
@@ -149,28 +149,34 @@ export const RecordingList = (props) => {
     return (<a href={props.url} download={!!props.download} target="_blank">{props.display || props.url}</a>);
   };
 
+  const RecordingsToolbar = (props) => {
+    return (
+      <Toolbar>
+        <ToolbarGroup>
+          <ToolbarItem>
+            <Button variant="primary" onClick={handleCreateRecording}>Create</Button>
+          </ToolbarItem>
+        </ToolbarGroup>
+        <ToolbarGroup>
+          <ToolbarItem>
+            <Button variant="secondary" onClick={handleStopRecordings} isDisabled={!checkedIndices.length}>Stop</Button>
+          </ToolbarItem>
+        </ToolbarGroup>
+        <ToolbarGroup>
+          <ToolbarItem>
+            <Button variant="danger" onClick={handleDeleteRecordings} isDisabled={!checkedIndices.length}>Delete</Button>
+          </ToolbarItem>
+        </ToolbarGroup>
+      </Toolbar>
+    );
+  };
+
   return (
     <TargetView pageTitle="Recordings">
       <Card>
         <CardHeader><Text component={TextVariants.h4}>Active Recordings</Text></CardHeader>
         <CardBody>
-          <Toolbar>
-            <ToolbarGroup>
-              <ToolbarItem>
-                <Button variant="primary" onClick={handleCreateRecording}>Create</Button>
-              </ToolbarItem>
-            </ToolbarGroup>
-            <ToolbarGroup>
-              <ToolbarItem>
-                <Button variant="secondary" onClick={handleStopRecordings}>Stop</Button>
-              </ToolbarItem>
-            </ToolbarGroup>
-            <ToolbarGroup>
-              <ToolbarItem>
-                <Button variant="danger" onClick={handleDeleteRecordings}>Delete</Button>
-              </ToolbarItem>
-            </ToolbarGroup>
-          </Toolbar>
+          <RecordingsToolbar />
           <DataList aria-label="Recording List">
             <DataListItem aria-labelledby="table-header-1">
               <DataListItemRow>

--- a/src/app/RecordingList/RecordingList.tsx
+++ b/src/app/RecordingList/RecordingList.tsx
@@ -78,6 +78,16 @@ export const RecordingList = (props) => {
     context.commandChannel.sendMessage('list');
   };
 
+  const handleStopRecordings = () => {
+    recordings.forEach((r: Recording, idx) => {
+      if (checkedIndices.includes(idx)) {
+        handleRowCheck(false, idx);
+        context.commandChannel.sendMessage('stop', [ r.name ]);
+      }
+    });
+    context.commandChannel.sendMessage('list');
+  };
+
   React.useEffect(() => {
     const sub = context.commandChannel.onResponse('list')
       .pipe(
@@ -147,7 +157,12 @@ export const RecordingList = (props) => {
           <Toolbar>
             <ToolbarGroup>
               <ToolbarItem>
-                <Button onClick={handleCreateRecording}>Create</Button>
+                <Button variant="primary" onClick={handleCreateRecording}>Create</Button>
+              </ToolbarItem>
+            </ToolbarGroup>
+            <ToolbarGroup>
+              <ToolbarItem>
+                <Button variant="secondary" onClick={handleStopRecordings}>Stop</Button>
               </ToolbarItem>
             </ToolbarGroup>
             <ToolbarGroup>


### PR DESCRIPTION
This is based on top of #59

Mockup: https://projects.invisionapp.com/d/main#/console/19772434/413969810/preview

This PR reimplements the Recording List as a Patternfly Data List, rather than as a Table. This allows more flexibility in the rendering of the cells - for example, the download and report URLs are now clickable links.

This also opens the door to more advanced custom styling options, such as making the rows expandable and containing more custom rendered elements (as opposed to an expandable table, which can only contain plain text). This could include copying the ContainerJFR Web Angular UI where the expanded rows contain an inline recording report. The Data List also allows for action buttons and other customized elements to be placed within the cells, which will likely be used for (re)implementing the "View in Grafana" feature.

In addition, checkboxes are added to each row of the table, as well as a header checkbox which acts as a select-all. These checkboxes are used in conjunction with the new Stop and Delete buttons, allowing these actions to be performed on recordings or batches of recordings.

![image](https://user-images.githubusercontent.com/3787464/80733920-e6195400-8afd-11ea-8d68-bfbce4273afd.png)
![image](https://user-images.githubusercontent.com/3787464/80733932-ed406200-8afd-11ea-884a-d30dbdef8815.png)
