### PR TITLE
Use eval-source-map in prod mode

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -8,7 +8,7 @@ const DotenvPlugin = require('dotenv-webpack');
 
 module.exports = merge(common, {
   mode: 'production',
-  devtool: 'source-map',
+  devtool: 'eval-source-map',
   optimization: {
     minimizer: [
       new TerserJSPlugin({}),


### PR DESCRIPTION
Fixes an issue where invalid prod mode source maps cause browsers to be
unable to open the client when built in prod mode.

See https://github.com/webpack/webpack/issues/8302