### PR TITLE
Add "Archived Recordings" view tab

### DIFF
--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -1,0 +1,181 @@
+import * as React from 'react';
+import { useHistory, useRouteMatch } from 'react-router-dom';
+import { filter, map } from 'rxjs/operators';
+import { Button, DataList, DataListCheck, DataListItem, DataListItemRow, DataListItemCells, DataListCell, Text, TextVariants, Title, Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+import { ServiceContext } from '@app/Shared/Services/Services';
+import { TargetView } from '@app/TargetView/TargetView';
+import { Recording, RecordingState } from './RecordingList';
+
+export const ActiveRecordingsList = (props) => {
+  const context = React.useContext(ServiceContext);
+  const routerHistory = useHistory();
+
+  const [recordings, setRecordings] = React.useState([]);
+  const [headerChecked, setHeaderChecked] = React.useState(false);
+  const [checkedIndices, setCheckedIndices] = React.useState([] as number[]);
+  const { url } = useRouteMatch();
+
+  const tableColumns: string[] = [
+    'Name',
+    'Start Time',
+    'Duration',
+    'Download',
+    'Report',
+    'State',
+  ];
+
+  const handleCreateRecording = () => {
+    routerHistory.push(`${url}/create`);
+  };
+
+  const handleHeaderCheck = (checked) => {
+    setHeaderChecked(checked);
+    setCheckedIndices(checked ? recordings.map((r, idx) => idx) : []);
+  };
+
+  const handleRowCheck = (checked, index) => {
+    if (checked) {
+      setCheckedIndices(ci => ([...ci, index]));
+    } else {
+      setHeaderChecked(false);
+      setCheckedIndices(ci => ci.filter(v => v !== index));
+    }
+  };
+
+  const handleDeleteRecordings = () => {
+    recordings.forEach((r: Recording, idx) => {
+      if (checkedIndices.includes(idx)) {
+        handleRowCheck(false, idx);
+        context.commandChannel.sendMessage('delete', [ r.name ]);
+      }
+    });
+    context.commandChannel.sendMessage('list');
+  };
+
+  const handleStopRecordings = () => {
+    recordings.forEach((r: Recording, idx) => {
+      if (checkedIndices.includes(idx)) {
+        handleRowCheck(false, idx);
+        if (r.state === RecordingState.RUNNING || r.state === RecordingState.STARTING) {
+          context.commandChannel.sendMessage('stop', [ r.name ]);
+        }
+      }
+    });
+    context.commandChannel.sendMessage('list');
+  };
+
+  React.useEffect(() => {
+    const sub = context.commandChannel.onResponse('list')
+      .pipe(
+        filter(m => m.status === 0),
+        map(m => m.payload),
+      )
+      .subscribe(recordings => setRecordings(recordings));
+    return () => sub.unsubscribe();
+  }, []);
+
+  React.useEffect(() => {
+    context.commandChannel.sendMessage('list');
+    const id = setInterval(() => context.commandChannel.sendMessage('list'), 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  const RecordingRow = (props) => {
+    return (
+      <DataListItemRow>
+        <DataListCheck aria-labelledby="table-row-1-1" name={`row-${props.index}-check`} onChange={(checked) => handleRowCheck(checked, props.index)} isChecked={checkedIndices.includes(props.index)} />
+        <DataListItemCells
+          dataListCells={[
+            <DataListCell key={`table-row-${props.index}-1`}>
+              {props.recording.name}
+            </DataListCell>,
+            <DataListCell key={`table-row-${props.index}-2`}>
+              <ISOTime timeStr={props.recording.startTime} />
+            </DataListCell>,
+            <DataListCell key={`table-row-${props.index}-3`}>
+              <RecordingDuration duration={props.recording.duration} />
+            </DataListCell>,
+            <DataListCell key={`table-row-${props.index}-4`}>
+              <Link url={`${props.recording.downloadUrl}.jfr`} />
+            </DataListCell>,
+            // TODO make row expandable and render report in collapsed iframe
+            <DataListCell key={`table-row-${props.index}-5`}>
+              <Link url={props.recording.reportUrl} />
+            </DataListCell>,
+            <DataListCell key={`table-row-${props.index}-6`}>
+              {props.recording.state}
+            </DataListCell>
+          ]}
+        />
+      </DataListItemRow>
+    );
+  };
+
+  const ISOTime = (props) => {
+    const fmt = new Date(props.timeStr).toISOString();
+    return (<span>{fmt}</span>);
+  };
+
+  const RecordingDuration = (props) => {
+    const str = props.duration === 0 ? 'Continuous' : `${props.duration / 1000}s`
+    return (<span>{str}</span>);
+  };
+
+  const Link = (props) => {
+    return (<a href={props.url} target="_blank">{props.display || props.url}</a>);
+  };
+
+  const isStopDisabled = () => {
+    if (!checkedIndices.length) {
+      return true;
+    }
+    const filtered = recordings.filter((r: Recording, idx: number) => checkedIndices.includes(idx));
+    const anyRunning = filtered.some((r: Recording) => r.state === RecordingState.RUNNING || r.state == RecordingState.STARTING);
+    return !anyRunning;
+  };
+
+  const RecordingsToolbar = (props) => {
+    return (
+      <Toolbar>
+        <ToolbarGroup>
+          <ToolbarItem>
+            <Button variant="primary" onClick={handleCreateRecording}>Create</Button>
+          </ToolbarItem>
+        </ToolbarGroup>
+        <ToolbarGroup>
+          <ToolbarItem>
+            <Button variant="secondary" onClick={handleStopRecordings} isDisabled={isStopDisabled()}>Stop</Button>
+          </ToolbarItem>
+        </ToolbarGroup>
+        <ToolbarGroup>
+          <ToolbarItem>
+            <Button variant="danger" onClick={handleDeleteRecordings} isDisabled={!checkedIndices.length}>Delete</Button>
+          </ToolbarItem>
+        </ToolbarGroup>
+      </Toolbar>
+    );
+  };
+
+  return (<>
+    <RecordingsToolbar />
+    <DataList aria-label="Recording List">
+      <DataListItem aria-labelledby="table-header-1">
+        <DataListItemRow>
+          <DataListCheck aria-labelledby="table-header-1" name="header-check" onChange={handleHeaderCheck} isChecked={headerChecked} />
+          <DataListItemCells
+            dataListCells={tableColumns.map((key , idx) => (
+              <DataListCell key={key}>
+                <span id={`table-header-${idx}`}>{key}</span>
+              </DataListCell>
+            ))}
+          />
+        </DataListItemRow>
+      </DataListItem>
+      <DataListItem aria-labelledby="table-row-1-1">
+      {
+        recordings.map((r, idx) => <RecordingRow recording={r} index={idx}/>)
+      }
+      </DataListItem>
+    </DataList>
+  </>);
+};

--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -5,12 +5,13 @@ import { Button, DataList, DataListCheck, DataListItem, DataListItemRow, DataLis
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { TargetView } from '@app/TargetView/TargetView';
 import { Recording, RecordingState } from './RecordingList';
+import { RecordingsDataTable } from './RecordingsDataTable';
 
 export interface ActiveRecordingsListProps {
   archiveEnabled: boolean;
 }
 
-export const ActiveRecordingsList = (props: ActiveRecordingsListProps) => {
+export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListProps> = (props) => {
   const context = React.useContext(ServiceContext);
   const routerHistory = useHistory();
 
@@ -28,15 +29,6 @@ export const ActiveRecordingsList = (props: ActiveRecordingsListProps) => {
     'State',
   ];
 
-  const handleCreateRecording = () => {
-    routerHistory.push(`${url}/create`);
-  };
-
-  const handleHeaderCheck = (checked) => {
-    setHeaderChecked(checked);
-    setCheckedIndices(checked ? recordings.map((r, idx) => idx) : []);
-  };
-
   const handleRowCheck = (checked, index) => {
     if (checked) {
       setCheckedIndices(ci => ([...ci, index]));
@@ -44,6 +36,15 @@ export const ActiveRecordingsList = (props: ActiveRecordingsListProps) => {
       setHeaderChecked(false);
       setCheckedIndices(ci => ci.filter(v => v !== index));
     }
+  };
+
+  const handleHeaderCheck = (checked) => {
+    setHeaderChecked(checked);
+    setCheckedIndices(checked ? Array.from(new Array(recordings.length), (x, i) => i) : []);
+  };
+
+  const handleCreateRecording = () => {
+    routerHistory.push(`${url}/create`);
   };
 
   const handleArchiveRecordings = () => {
@@ -149,41 +150,25 @@ export const ActiveRecordingsList = (props: ActiveRecordingsListProps) => {
 
   const RecordingsToolbar = () => {
     const buttons = [
-      <ToolbarGroup>
-        <ToolbarItem>
-          <Button variant="primary" onClick={handleCreateRecording}>Create</Button>
-        </ToolbarItem>
-      </ToolbarGroup>
+      <Button variant="primary" onClick={handleCreateRecording}>Create</Button>
     ];
     if (props.archiveEnabled) {
       buttons.push((
-        <ToolbarGroup>
-          <ToolbarItem>
-            <Button variant="secondary" onClick={handleArchiveRecordings} isDisabled={!checkedIndices.length}>Archive</Button>
-          </ToolbarItem>
-        </ToolbarGroup>
+        <Button variant="secondary" onClick={handleArchiveRecordings} isDisabled={!checkedIndices.length}>Archive</Button>
       ));
     }
     buttons.push((
-      <ToolbarGroup>
-        <ToolbarItem>
-          <Button variant="tertiary" onClick={handleStopRecordings} isDisabled={isStopDisabled()}>Stop</Button>
-        </ToolbarItem>
-      </ToolbarGroup>
+      <Button variant="tertiary" onClick={handleStopRecordings} isDisabled={isStopDisabled()}>Stop</Button>
     ));
     buttons.push((
-      <ToolbarGroup>
-        <ToolbarItem>
-          <Button variant="danger" onClick={handleDeleteRecordings} isDisabled={!checkedIndices.length}>Delete</Button>
-        </ToolbarItem>
-      </ToolbarGroup>
+      <Button variant="danger" onClick={handleDeleteRecordings} isDisabled={!checkedIndices.length}>Delete</Button>
     ));
 
     return (
       <Toolbar>
         {
-          buttons.map(btn => (
-            <ToolbarGroup>
+          buttons.map((btn, idx) => (
+            <ToolbarGroup key={idx}>
               <ToolbarItem>
                 { btn }
               </ToolbarItem>
@@ -195,25 +180,16 @@ export const ActiveRecordingsList = (props: ActiveRecordingsListProps) => {
   };
 
   return (<>
-    <RecordingsToolbar />
-    <DataList aria-label="Active Recording List">
-      <DataListItem aria-labelledby="table-header-1">
-        <DataListItemRow>
-          <DataListCheck aria-labelledby="table-header-1" name="header-check" onChange={handleHeaderCheck} isChecked={headerChecked} />
-          <DataListItemCells
-            dataListCells={tableColumns.map((key , idx) => (
-              <DataListCell key={key}>
-                <span id={`table-header-${idx}`}>{key}</span>
-              </DataListCell>
-            ))}
-          />
-        </DataListItemRow>
-      </DataListItem>
-      <DataListItem aria-labelledby="table-row-1-1">
+    <RecordingsDataTable
+        listTitle="Active Flight Recordings"
+        toolbar={<RecordingsToolbar />}
+        tableColumns={tableColumns}
+        isHeaderChecked={headerChecked}
+        onHeaderCheck={handleHeaderCheck}
+    >
       {
         recordings.map((r, idx) => <RecordingRow recording={r} index={idx}/>)
       }
-      </DataListItem>
-    </DataList>
+    </RecordingsDataTable>
   </>);
 };

--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useHistory, useRouteMatch } from 'react-router-dom';
 import { filter, map } from 'rxjs/operators';
-import { Button, DataList, DataListCheck, DataListItem, DataListItemRow, DataListItemCells, DataListCell, Text, TextVariants, Title, Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+import { Button, DataList, DataListCheck, DataListItem, DataListItemRow, DataListItemCells, DataListCell, DataToolbar, DataToolbarContent, DataToolbarItem, Text, TextVariants, Title } from '@patternfly/react-core';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { TargetView } from '@app/TargetView/TargetView';
 import { Recording, RecordingState } from './RecordingList';
@@ -165,17 +165,17 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
     ));
 
     return (
-      <Toolbar>
+      <DataToolbar id="active-recordings-toolbar">
+        <DataToolbarContent>
         {
           buttons.map((btn, idx) => (
-            <ToolbarGroup key={idx}>
-              <ToolbarItem>
+              <DataToolbarItem key={idx}>
                 { btn }
-              </ToolbarItem>
-            </ToolbarGroup>
+              </DataToolbarItem>
           ))
         }
-      </Toolbar>
+        </DataToolbarContent>
+      </DataToolbar>
     );
   };
 

--- a/src/app/RecordingList/ArchivedRecordingsList.tsx
+++ b/src/app/RecordingList/ArchivedRecordingsList.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { filter, map } from 'rxjs/operators';
-import { Button, DataList, DataListCheck, DataListItem, DataListItemRow, DataListItemCells, DataListCell, Text, TextVariants, Title, Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+import { Button, DataList, DataListCheck, DataListItem, DataListItemRow, DataListItemCells, DataListCell, DataToolbar, DataToolbarContent, DataToolbarItem, Text, TextVariants, Title } from '@patternfly/react-core';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { TargetView } from '@app/TargetView/TargetView';
 import { Recording, RecordingState } from './RecordingList';
@@ -92,13 +92,13 @@ export const ArchivedRecordingsList = (props) => {
 
   const RecordingsToolbar = (props) => {
     return (
-      <Toolbar>
-        <ToolbarGroup>
-          <ToolbarItem>
+      <DataToolbar id="archived-recordings-toolbar">
+        <DataToolbarContent>
+          <DataToolbarItem>
             <Button variant="danger" onClick={handleDeleteRecordings} isDisabled={!checkedIndices.length}>Delete</Button>
-          </ToolbarItem>
-        </ToolbarGroup>
-      </Toolbar>
+          </DataToolbarItem>
+        </DataToolbarContent>
+      </DataToolbar>
     );
   };
 

--- a/src/app/RecordingList/ArchivedRecordingsList.tsx
+++ b/src/app/RecordingList/ArchivedRecordingsList.tsx
@@ -4,6 +4,7 @@ import { Button, DataList, DataListCheck, DataListItem, DataListItemRow, DataLis
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { TargetView } from '@app/TargetView/TargetView';
 import { Recording, RecordingState } from './RecordingList';
+import { RecordingsDataTable } from './RecordingsDataTable';
 
 export const ArchivedRecordingsList = (props) => {
   const context = React.useContext(ServiceContext);
@@ -20,7 +21,7 @@ export const ArchivedRecordingsList = (props) => {
 
   const handleHeaderCheck = (checked) => {
     setHeaderChecked(checked);
-    setCheckedIndices(checked ? recordings.map((r, idx) => idx) : []);
+    setCheckedIndices(checked ? Array.from(new Array(recordings.length), (x, i) => i) : []);
   };
 
   const handleRowCheck = (checked, index) => {
@@ -102,25 +103,16 @@ export const ArchivedRecordingsList = (props) => {
   };
 
   return (<>
-    <RecordingsToolbar />
-    <DataList aria-label="Archived Recording List">
-      <DataListItem aria-labelledby="table-header-1">
-        <DataListItemRow>
-          <DataListCheck aria-labelledby="table-header-1" name="header-check" onChange={handleHeaderCheck} isChecked={headerChecked} />
-          <DataListItemCells
-            dataListCells={tableColumns.map((key , idx) => (
-              <DataListCell key={key}>
-                <span id={`table-header-${idx}`}>{key}</span>
-              </DataListCell>
-            ))}
-          />
-        </DataListItemRow>
-      </DataListItem>
-      <DataListItem aria-labelledby="table-row-1-1">
+    <RecordingsDataTable
+        listTitle="Archived Flight Recordings"
+        toolbar={<RecordingsToolbar />}
+        tableColumns={tableColumns}
+        isHeaderChecked={headerChecked}
+        onHeaderCheck={handleHeaderCheck}
+    >
       {
         recordings.map((r, idx) => <RecordingRow recording={r} index={idx}/>)
       }
-      </DataListItem>
-    </DataList>
+    </RecordingsDataTable>
   </>);
 };

--- a/src/app/RecordingList/ArchivedRecordingsList.tsx
+++ b/src/app/RecordingList/ArchivedRecordingsList.tsx
@@ -43,6 +43,11 @@ export const ArchivedRecordingsList = (props) => {
   };
 
   React.useEffect(() => {
+    const sub = context.commandChannel.onResponse('save').subscribe(() => context.commandChannel.sendMessage('list-saved'));
+    return () => sub.unsubscribe();
+  });
+
+  React.useEffect(() => {
     const sub = context.commandChannel.onResponse('list-saved')
       .pipe(
         filter(m => m.status === 0),

--- a/src/app/RecordingList/RecordingList.tsx
+++ b/src/app/RecordingList/RecordingList.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
-import { useHistory, useRouteMatch } from 'react-router-dom';
-import { filter, map } from 'rxjs/operators';
-import { Button, Card, CardBody, CardHeader, DataList, DataListCheck, DataListItem, DataListItemRow, DataListItemCells, DataListCell, PageSection, Text, TextVariants, Title, Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
-import { ServiceContext } from '@app/Shared/Services/Services';
+import { Card, CardBody, CardHeader, Text, TextVariants  } from '@patternfly/react-core';
 import { TargetView } from '@app/TargetView/TargetView';
+import { ActiveRecordingsList } from './ActiveRecordingsList';
 
-interface Recording {
+export interface Recording {
   id: number;
   name: string;
   state: RecordingState;
@@ -19,7 +17,7 @@ interface Recording {
   reportUrl: string;
 }
 
-enum RecordingState {
+export enum RecordingState {
   STOPPED = 'STOPPED',
   STARTING = 'STARTING',
   RUNNING = 'RUNNING',
@@ -27,180 +25,12 @@ enum RecordingState {
 }
 
 export const RecordingList = (props) => {
-  const context = React.useContext(ServiceContext);
-  const routerHistory = useHistory();
-
-  const [recordings, setRecordings] = React.useState([]);
-  const [headerChecked, setHeaderChecked] = React.useState(false);
-  const [checkedIndices, setCheckedIndices] = React.useState([] as number[]);
-  const { path, url } = useRouteMatch();
-
-  const tableColumns: string[] = [
-    'Name',
-    'Start Time',
-    'Duration',
-    'Download',
-    'Report',
-    'State',
-  ];
-
-  const handleCreateRecording = () => {
-    routerHistory.push(`${url}/create`);
-  };
-
-  const handleHeaderCheck = (checked) => {
-    setHeaderChecked(checked);
-    setCheckedIndices(checked ? recordings.map((r, idx) => idx) : []);
-  };
-
-  const handleRowCheck = (checked, index) => {
-    if (checked) {
-      setCheckedIndices(ci => ([...ci, index]));
-    } else {
-      setHeaderChecked(false);
-      setCheckedIndices(ci => ci.filter(v => v !== index));
-    }
-  };
-
-  const handleDeleteRecordings = () => {
-    recordings.forEach((r: Recording, idx) => {
-      if (checkedIndices.includes(idx)) {
-        handleRowCheck(false, idx);
-        context.commandChannel.sendMessage('delete', [ r.name ]);
-      }
-    });
-    context.commandChannel.sendMessage('list');
-  };
-
-  const handleStopRecordings = () => {
-    recordings.forEach((r: Recording, idx) => {
-      if (checkedIndices.includes(idx)) {
-        handleRowCheck(false, idx);
-        if (r.state === RecordingState.RUNNING || r.state === RecordingState.STARTING) {
-          context.commandChannel.sendMessage('stop', [ r.name ]);
-        }
-      }
-    });
-    context.commandChannel.sendMessage('list');
-  };
-
-  React.useEffect(() => {
-    const sub = context.commandChannel.onResponse('list')
-      .pipe(
-        filter(m => m.status === 0),
-        map(m => m.payload),
-      )
-      .subscribe(recordings => setRecordings(recordings));
-    return () => sub.unsubscribe();
-  }, []);
-
-  React.useEffect(() => {
-    context.commandChannel.sendMessage('list');
-    const id = setInterval(() => context.commandChannel.sendMessage('list'), 5000);
-    return () => clearInterval(id);
-  }, []);
-
-  const RecordingRow = (props) => {
-    return (
-      <DataListItemRow>
-        <DataListCheck aria-labelledby="table-row-1-1" name={`row-${props.index}-check`} onChange={(checked) => handleRowCheck(checked, props.index)} isChecked={checkedIndices.includes(props.index)} />
-        <DataListItemCells
-          dataListCells={[
-            <DataListCell key={`table-row-${props.index}-1`}>
-              {props.recording.name}
-            </DataListCell>,
-            <DataListCell key={`table-row-${props.index}-2`}>
-              <ISOTime timeStr={props.recording.startTime} />
-            </DataListCell>,
-            <DataListCell key={`table-row-${props.index}-3`}>
-              <RecordingDuration duration={props.recording.duration} />
-            </DataListCell>,
-            <DataListCell key={`table-row-${props.index}-4`}>
-              <Link url={`${props.recording.downloadUrl}.jfr`} />
-            </DataListCell>,
-            // TODO make row expandable and render report in collapsed iframe
-            <DataListCell key={`table-row-${props.index}-5`}>
-              <Link url={props.recording.reportUrl} />
-            </DataListCell>,
-            <DataListCell key={`table-row-${props.index}-6`}>
-              {props.recording.state}
-            </DataListCell>
-          ]}
-        />
-      </DataListItemRow>
-    );
-  };
-
-  const ISOTime = (props) => {
-    const fmt = new Date(props.timeStr).toISOString();
-    return (<span>{fmt}</span>);
-  };
-
-  const RecordingDuration = (props) => {
-    const str = props.duration === 0 ? 'Continuous' : `${props.duration / 1000}s`
-    return (<span>{str}</span>);
-  };
-
-  const Link = (props) => {
-    return (<a href={props.url} target="_blank">{props.display || props.url}</a>);
-  };
-
-  const isStopDisabled = () => {
-    if (!checkedIndices.length) {
-      return true;
-    }
-    const filtered = recordings.filter((r: Recording, idx: number) => checkedIndices.includes(idx));
-    const anyRunning = filtered.some((r: Recording) => r.state === RecordingState.RUNNING || r.state == RecordingState.STARTING);
-    return !anyRunning;
-  };
-
-  const RecordingsToolbar = (props) => {
-    return (
-      <Toolbar>
-        <ToolbarGroup>
-          <ToolbarItem>
-            <Button variant="primary" onClick={handleCreateRecording}>Create</Button>
-          </ToolbarItem>
-        </ToolbarGroup>
-        <ToolbarGroup>
-          <ToolbarItem>
-            <Button variant="secondary" onClick={handleStopRecordings} isDisabled={isStopDisabled()}>Stop</Button>
-          </ToolbarItem>
-        </ToolbarGroup>
-        <ToolbarGroup>
-          <ToolbarItem>
-            <Button variant="danger" onClick={handleDeleteRecordings} isDisabled={!checkedIndices.length}>Delete</Button>
-          </ToolbarItem>
-        </ToolbarGroup>
-      </Toolbar>
-    );
-  };
-
   return (
     <TargetView pageTitle="Recordings">
       <Card>
         <CardHeader><Text component={TextVariants.h4}>Active Recordings</Text></CardHeader>
         <CardBody>
-          <RecordingsToolbar />
-          <DataList aria-label="Recording List">
-            <DataListItem aria-labelledby="table-header-1">
-              <DataListItemRow>
-                <DataListCheck aria-labelledby="table-header-1" name="header-check" onChange={handleHeaderCheck} isChecked={headerChecked} />
-                <DataListItemCells
-                  dataListCells={tableColumns.map((key , idx) => (
-                    <DataListCell key={key}>
-                      <span id={`table-header-${idx}`}>{key}</span>
-                    </DataListCell>
-                  ))}
-                />
-              </DataListItemRow>
-            </DataListItem>
-            <DataListItem aria-labelledby="table-row-1-1">
-            {
-              recordings.map((r, idx) => <RecordingRow recording={r} index={idx}/>)
-            }
-            </DataListItem>
-          </DataList>
+          <ActiveRecordingsList />
         </CardBody>
       </Card>
     </TargetView>

--- a/src/app/RecordingList/RecordingList.tsx
+++ b/src/app/RecordingList/RecordingList.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
-import { Card, CardBody, CardHeader, Text, TextVariants  } from '@patternfly/react-core';
+import { Card, CardBody, CardHeader, Tabs, Tab, Text, TextVariants } from '@patternfly/react-core';
+import { ServiceContext } from '@app/Shared/Services/Services';
 import { TargetView } from '@app/TargetView/TargetView';
 import { ActiveRecordingsList } from './ActiveRecordingsList';
+import { ArchivedRecordingsList } from './ArchivedRecordingsList';
 
 export interface Recording {
   id: number;
@@ -25,12 +27,36 @@ export enum RecordingState {
 }
 
 export const RecordingList = (props) => {
+  const context = React.useContext(ServiceContext);
+  const [activeTab, setActiveTab] = React.useState(0);
+  const [archiveEnabled, setArchiveEnabled] = React.useState(false);
+
+  React.useEffect(() => {
+    const sub = context.commandChannel.isArchiveEnabled().subscribe(enabled => setArchiveEnabled(enabled));
+    return () => sub.unsubscribe();
+  }, []);
+
   return (
     <TargetView pageTitle="Recordings">
       <Card>
-        <CardHeader><Text component={TextVariants.h4}>Active Recordings</Text></CardHeader>
         <CardBody>
-          <ActiveRecordingsList />
+          {
+            archiveEnabled ? (
+              <Tabs activeKey={activeTab} onSelect={(evt, idx) => setActiveTab(Number(idx))}>
+                <Tab eventKey={0} title="Active Recordings">
+                  <ActiveRecordingsList />
+                </Tab>
+                <Tab eventKey={1} title="Archived Recordings">
+                  <ArchivedRecordingsList />
+                </Tab>
+              </Tabs>
+            ) : (
+              <>
+                <CardHeader><Text component={TextVariants.h4}>Active Recordings</Text></CardHeader>
+                <ActiveRecordingsList />
+              </>
+            )
+          }
         </CardBody>
       </Card>
     </TargetView>

--- a/src/app/RecordingList/RecordingList.tsx
+++ b/src/app/RecordingList/RecordingList.tsx
@@ -44,7 +44,7 @@ export const RecordingList = (props) => {
             archiveEnabled ? (
               <Tabs activeKey={activeTab} onSelect={(evt, idx) => setActiveTab(Number(idx))}>
                 <Tab eventKey={0} title="Active Recordings">
-                  <ActiveRecordingsList />
+                  <ActiveRecordingsList archiveEnabled={true}/>
                 </Tab>
                 <Tab eventKey={1} title="Archived Recordings">
                   <ArchivedRecordingsList />
@@ -53,7 +53,7 @@ export const RecordingList = (props) => {
             ) : (
               <>
                 <CardHeader><Text component={TextVariants.h4}>Active Recordings</Text></CardHeader>
-                <ActiveRecordingsList />
+                <ActiveRecordingsList archiveEnabled={false}/>
               </>
             )
           }

--- a/src/app/RecordingList/RecordingsDataTable.tsx
+++ b/src/app/RecordingList/RecordingsDataTable.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { DataList, DataListCheck, DataListItem, DataListItemRow, DataListItemCells, DataListCell, Toolbar } from '@patternfly/react-core';
+
+export interface RecordingsDataTableProps {
+  toolbar: React.ReactElement;
+  tableColumns: string[];
+  listTitle: string;
+  isHeaderChecked: boolean;
+  onHeaderCheck: (checked: boolean) => void;
+}
+
+export const RecordingsDataTable: React.FunctionComponent<RecordingsDataTableProps> = (props) => {
+  return (<>
+    { props.toolbar }
+    <DataList aria-label={props.listTitle}>
+      <DataListItem aria-labelledby="table-header-1">
+        <DataListItemRow>
+          <DataListCheck aria-labelledby="table-header-1" name="header-check" onChange={props.onHeaderCheck} isChecked={props.isHeaderChecked} />
+          <DataListItemCells
+            dataListCells={props.tableColumns.map((key , idx) => (
+              <DataListCell key={key}>
+                <span id={`table-header-${idx}`}>{key}</span>
+              </DataListCell>
+            ))}
+          />
+        </DataListItemRow>
+      </DataListItem>
+      { props.children }
+    </DataList>
+  </>);
+};


### PR DESCRIPTION
Adds a conditionally-displayed Archived Recordings tab to the Recordings List card component. If the ContainerJFR instance does not support recording archiving then the UI is unchanged - no tabs are displayed on the card, only the Active Recordings table. If Archives are supported then the active recording list gains an Archive button, and the new view allows a list of archived recordings to be seen, downloaded, and deleted, as well as reports viewed by link URL.

![image](https://user-images.githubusercontent.com/3787464/80982087-571c7c80-8e1a-11ea-8bd1-9f916ebcd027.png)
![image](https://user-images.githubusercontent.com/3787464/80982106-60a5e480-8e1a-11ea-835e-972ff7092fcb.png)
![image](https://user-images.githubusercontent.com/3787464/80982145-6dc2d380-8e1a-11ea-92d6-46ef8174e348.png)
