### PR TITLE
Add action button for creating recordings from template

### DIFF
--- a/src/app/CreateRecording/CreateRecording.tsx
+++ b/src/app/CreateRecording/CreateRecording.tsx
@@ -11,6 +11,7 @@ export interface CreateRecordingProps {
   recordingName?: string;
   template?: string;
   eventSpecifiers?: string[];
+  location?: any;
 }
 
 export interface EventTemplate {
@@ -43,6 +44,10 @@ export const CreateRecording = (props: CreateRecordingProps) => {
     context.commandChannel.sendMessage(command, args, id);
   };
 
+  React.useEffect(() => {
+    console.log('CreateRecording', { props });
+  }, []);
+
   return (
     <PageSection>
       <Breadcrumb>
@@ -53,7 +58,11 @@ export const CreateRecording = (props: CreateRecordingProps) => {
         <CardBody>
           <Tabs activeKey={activeTab} onSelect={(evt, idx) => setActiveTab(Number(idx))}>
             <Tab eventKey={0} title="Custom Flight Recording">
-              <CustomRecordingForm onSubmit={handleSubmit} />
+              <CustomRecordingForm onSubmit={handleSubmit}
+                recordingName={props?.location?.state?.recordingName}
+                template={props?.location?.state?.template}
+                eventSpecifiers={props?.location?.state?.eventSpecifiers}
+              />
             </Tab>
             <Tab eventKey={1} title="Snapshot Recording">
               <SnapshotRecordingForm onSubmit={handleSubmit} />

--- a/src/app/CreateRecording/CustomRecordingForm.tsx
+++ b/src/app/CreateRecording/CustomRecordingForm.tsx
@@ -21,15 +21,19 @@ export const CustomRecordingForm = (props) => {
   const notifications = React.useContext(NotificationsContext);
   const history = useHistory();
 
-  const [recordingName, setRecordingName] = React.useState(props.recordingName || '');
+  const [recordingName, setRecordingName] = React.useState(props.recordingName || props?.location?.state?.recordingName || '');
   const [nameValid, setNameValid] = React.useState(false);
   const [continuous, setContinuous] = React.useState(false);
   const [duration, setDuration] = React.useState(30);
   const [durationUnit, setDurationUnit] = React.useState(1);
   const [templates, setTemplates] = React.useState([] as EventTemplate[]);
-  const [template, setTemplate] = React.useState('');
-  const [eventSpecifiers, setEventSpecifiers] = React.useState('');
-  const [eventsValid, setEventsValid] = React.useState(false);
+  const [template, setTemplate] = React.useState(props.template || props?.location?.state?.template ||  '');
+  const [eventSpecifiers, setEventSpecifiers] = React.useState(props?.eventSpecifiers?.join(' ') || '');
+  const [eventsValid, setEventsValid] = React.useState(!!props.template || !!props?.location?.state?.template);
+
+  React.useEffect(() => {
+    console.log('CustomRecordingForm', { props });
+  }, []);
 
   const handleContinuousChange = (checked, evt) => {
     setContinuous(evt.target.checked);

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { filter, map } from 'rxjs/operators';
 import { TextInput, Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
 import { Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-table';
+import { useHistory } from 'react-router-dom';
 import { ServiceContext } from '@app/Shared/Services/Services';
 
 export interface EventTemplate {
@@ -12,6 +13,7 @@ export interface EventTemplate {
 
 export const EventTemplates = (props) => {
   const context = React.useContext(ServiceContext);
+  const history = useHistory();
 
   const [templates, setTemplates] = React.useState([]);
   const [filterText, setFilterText] = React.useState('');
@@ -35,6 +37,13 @@ export const EventTemplates = (props) => {
     );
   };
 
+  const actions = [
+    {
+      title: 'Create Recording from Template',
+      onClick: (event, rowId, rowData, extra) => history.push({ pathname: '/recordings/create', state: { template: rowData[0] } })
+    }
+  ];
+
   React.useEffect(() => {
     const sub = context.commandChannel.onResponse('list-event-templates')
       .pipe(
@@ -57,7 +66,7 @@ export const EventTemplates = (props) => {
         </ToolbarItem>
       </ToolbarGroup>
     </Toolbar>
-    <Table aria-label="Event Templates table" cells={tableColumns} rows={getTemplates()} variant={TableVariant.compact}>
+    <Table aria-label="Event Templates table" cells={tableColumns} rows={getTemplates()} actions={actions} variant={TableVariant.compact}>
       <TableHeader />
       <TableBody />
     </Table>

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -58,7 +58,7 @@ export const EventTemplates = (props) => {
     context.commandChannel.sendMessage('list-event-templates');
   }, []);
 
-  return(<>
+  return (<>
     <DataToolbar id="event-templates-toolbar">
       <DataToolbarContent>
         <DataToolbarItem>

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { filter, map } from 'rxjs/operators';
-import { TextInput, Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+import { DataToolbar, DataToolbarContent, DataToolbarItem, TextInput } from '@patternfly/react-core';
 import { Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-table';
 import { useHistory } from 'react-router-dom';
 import { ServiceContext } from '@app/Shared/Services/Services';
@@ -59,13 +59,13 @@ export const EventTemplates = (props) => {
   }, []);
 
   return(<>
-    <Toolbar>
-      <ToolbarGroup>
-        <ToolbarItem>
+    <DataToolbar id="event-templates-toolbar">
+      <DataToolbarContent>
+        <DataToolbarItem>
           <TextInput name="templateFilter" id="templateFilter" type="search" placeholder="Filter..." aria-label="Event template filter" onChange={setFilterText}/>
-        </ToolbarItem>
-      </ToolbarGroup>
-    </Toolbar>
+        </DataToolbarItem>
+      </DataToolbarContent>
+    </DataToolbar>
     <Table aria-label="Event Templates table" cells={tableColumns} rows={getTemplates()} actions={actions} variant={TableVariant.compact}>
       <TableHeader />
       <TableBody />

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { filter, map } from 'rxjs/operators';
-import { Pagination, Split, SplitItem, TextInput } from '@patternfly/react-core';
+import { DataToolbar, DataToolbarContent, DataToolbarItem, DataToolbarItemVariant, Pagination, TextInput } from '@patternfly/react-core';
 import { Table, TableBody, TableHeader, TableVariant, expandable } from '@patternfly/react-table';
 import { ServiceContext } from '@app/Shared/Services/Services';
 
@@ -125,23 +125,24 @@ export const EventTypes = (props) => {
 
   // TODO replace table with data list so collapsed event options can be custom formatted
   return(<>
-    <Split>
-      <SplitItem>
-        <TextInput name="eventFilter" id="eventFilter" type="search" placeholder="Filter..." aria-label="Event filter" onChange={setFilterText}/>
-      </SplitItem>
-      <SplitItem isFilled />
-      <SplitItem>
-        <Pagination
-          itemCount={!!filterText ? filterTypesByText(types, filterText).length : types.length}
-          page={currentPage}
-          perPage={perPage}
-          onSetPage={onCurrentPage}
-          widgetId="event-types-pagination"
-          onPerPageSelect={onPerPage}
-          isCompact
-        />
-      </SplitItem>
-    </Split>
+    <DataToolbar id="event-types-toolbar">
+      <DataToolbarContent>
+        <DataToolbarItem>
+          <TextInput name="eventFilter" id="eventFilter" type="search" placeholder="Filter..." aria-label="Event filter" onChange={setFilterText}/>
+        </DataToolbarItem>
+        <DataToolbarItem variant={DataToolbarItemVariant.pagination}>
+          <Pagination
+            itemCount={!!filterText ? filterTypesByText(types, filterText).length : types.length}
+            page={currentPage}
+            perPage={perPage}
+            onSetPage={onCurrentPage}
+            widgetId="event-types-pagination"
+            onPerPageSelect={onPerPage}
+            isCompact
+          />
+        </DataToolbarItem>
+      </DataToolbarContent>
+    </DataToolbar>
     <Table aria-label="Event Types table" cells={tableColumns} rows={displayedTypes} onCollapse={onCollapse} variant={TableVariant.compact}>
       <TableHeader />
       <TableBody />

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -124,7 +124,7 @@ export const EventTypes = (props) => {
   };
 
   // TODO replace table with data list so collapsed event options can be custom formatted
-  return(<>
+  return (<>
     <DataToolbar id="event-types-toolbar">
       <DataToolbarContent>
         <DataToolbarItem>

--- a/src/app/Events/Events.tsx
+++ b/src/app/Events/Events.tsx
@@ -16,7 +16,7 @@ export const Events = (props) => {
       <Card>
         <CardHeader><Text component={TextVariants.h4}>Events</Text></CardHeader>
         <CardBody>
-          <Tabs isFilled mountOnEnter unmountOnExit activeKey={activeTab} onSelect={handleTabSelect}>
+          <Tabs isFilled activeKey={activeTab} onSelect={handleTabSelect}>
             <Tab eventKey={0} title="Event Templates">
               <EventTemplates />
             </Tab>


### PR DESCRIPTION
This adds an action button menu to each row of the Event Templates view, currently containing a single action button. When clicked this action button routes the user to the Create Recording form view, with the template/eventSpecifier fields of the form pre-filled and validated according to the event template that the user chose on the previous view.

![image](https://user-images.githubusercontent.com/3787464/80981915-22102a00-8e1a-11ea-850e-8a13a9dfb0e0.png)
![image](https://user-images.githubusercontent.com/3787464/80981972-305e4600-8e1a-11ea-9ac0-841253e93d21.png)
![image](https://user-images.githubusercontent.com/3787464/80848832-2a8f1780-8c04-11ea-8109-8b45f24eb55c.png)
