### PR TITLE
Fix React linting issues

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { NavLink, useRouteMatch } from 'react-router-dom';
+import { NavLink, matchPath, useLocation } from 'react-router-dom';
 import {
   Nav,
   NavList,
@@ -28,11 +28,12 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
   const [isMobileView, setIsMobileView] = React.useState(true);
   const [isNavOpenMobile, setIsNavOpenMobile] = React.useState(false);
   const [availableRoutes, setAvailableRoutes] = React.useState(staticRoutes);
+  const location = useLocation();
 
   React.useEffect(() => {
     const sub = context.commandChannel.isConnected().subscribe(isConnected => setAvailableRoutes(getAvailableRoutes(isConnected)));
     return () => sub.unsubscribe();
-  }, []);
+  }, [context.commandChannel]);
 
   const onNavToggleMobile = () => {
     setIsNavOpenMobile(!isNavOpenMobile);
@@ -54,10 +55,10 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
   );
 
   const isActiveRoute = (route: IAppRoute): boolean => {
-    const match = useRouteMatch(route);
-    if (!!match && match.isExact) {
+    const match = matchPath(location.pathname, route.path);
+    if (match && match.isExact) {
       return true;
-    } else if (!!route.children) {
+    } else if (route.children) {
       let childMatch = false;
       for (const r of route.children) {
         childMatch = childMatch || isActiveRoute(r);

--- a/src/app/BreadcrumbPage/BreadcrumbPage.tsx
+++ b/src/app/BreadcrumbPage/BreadcrumbPage.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Breadcrumb, BreadcrumbHeading, BreadcrumbItem, PageSection, Stack, StackItem, } from '@patternfly/react-core';
-import { TargetSelect } from '@app/TargetSelect/TargetSelect';
 
 interface BreadcrumbPageProps {
   children?: { isFilled?: boolean };
@@ -17,13 +16,13 @@ export const BreadcrumbPage = (props: BreadcrumbPageProps) => {
   return (<>
     <PageSection>
       <Breadcrumb>
-        {(props.breadcrumbs || []).map(({ title, path }) => (<BreadcrumbItem to={path}>{title}</BreadcrumbItem>))}
+        {(props.breadcrumbs || []).map(({ title, path }, idx) => (<BreadcrumbItem key={idx} to={path}>{title}</BreadcrumbItem>))}
         <BreadcrumbHeading>{props.pageTitle}</BreadcrumbHeading>
       </Breadcrumb>
       <Stack gutter="md">
         {
-          React.Children.map(props.children, child => (
-            <StackItem isFilled={!!child && child.isFilled}>
+          React.Children.map(props.children, (child, idx) => (
+            <StackItem isFilled={child && child.isFilled} key={idx}>
               {child}
             </StackItem>
           ))

--- a/src/app/CreateRecording/CreateRecording.tsx
+++ b/src/app/CreateRecording/CreateRecording.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import { filter, first, map } from 'rxjs/operators';
-import { ActionGroup, Breadcrumb, BreadcrumbHeading, BreadcrumbItem, Button, Card, CardBody, CardHeader, Checkbox, Form, FormGroup, FormSelect, FormSelectOption, FormSelectOptionGroup, TextArea, TextInput, PageSection, Split, SplitItem, Text, TextVariants, Title, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { ActionGroup, Breadcrumb, BreadcrumbHeading, BreadcrumbItem, Button, Card, CardBody, Checkbox, Form, FormGroup, FormSelect, FormSelectOption, FormSelectOptionGroup, TextArea, TextInput, PageSection, Split, SplitItem, Text, TextVariants, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { NotificationsContext } from '@app/Notifications/Notifications';
-import { AlertVariant } from '@patternfly/react-core';
 
 export interface CreateRecordingProps {
   recordingName?: string;
@@ -21,7 +20,7 @@ export interface EventTemplate {
 
 export const RecordingNamePattern = /^[\w_]+$/;
 export const TemplatePattern = /^template=([\w]+)$/;
-export const EventSpecifierPattern = /([\w\\.\$]+):([\w]+)=([\w\\d\.]+)/;
+export const EventSpecifierPattern = /([\w.$]+):([\w]+)=([\w\d.]+)/;
 
 export const CreateRecording = (props: CreateRecordingProps) => {
   const context = React.useContext(ServiceContext);
@@ -62,9 +61,9 @@ export const CreateRecording = (props: CreateRecordingProps) => {
     setEventSpecifiers(evt);
   };
 
-  const getEventSpecifiers = () => !!template ? `template=${template}` : eventSpecifiers;
+  const getEventSpecifiers = () => template ? `template=${template}` : eventSpecifiers;
 
-  const getEventString = () => !!template ? `template=${template}` : eventSpecifiers.split(/\s+/).filter(Boolean).join(',');
+  const getEventString = () => template ? `template=${template}` : eventSpecifiers.split(/\s+/).filter(Boolean).join(',');
 
   const handleRecordingNameChange = (name) => {
     setNameValid(RecordingNamePattern.test(name));
@@ -74,7 +73,7 @@ export const CreateRecording = (props: CreateRecordingProps) => {
   const handleSubmit = () => {
     const eventString = getEventString();
 
-    let notificationMessages: string[] = [];
+    const notificationMessages: string[] = [];
     if (!nameValid) {
       notificationMessages.push(`Recording name ${recordingName} is invalid`);
     }
@@ -118,11 +117,11 @@ export const CreateRecording = (props: CreateRecordingProps) => {
       )
       .subscribe(m => setTemplates(m));
     return () => sub.unsubscribe();
-  }, []);
+  }, [context.commandChannel]);
 
   React.useEffect(() => {
     context.commandChannel.sendMessage('list-event-templates');
-  }, []);
+  }, [context.commandChannel]);
 
   React.useEffect(() => {
     if (TemplatePattern.test(eventSpecifiers)) {
@@ -131,7 +130,7 @@ export const CreateRecording = (props: CreateRecordingProps) => {
         return;
       }
       const template = regexMatches[1];
-      if (!!templates.find(t => t.name === template)) {
+      if (templates.find(t => t.name === template)) {
         handleTemplateChange(template);
       }
     }

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -1,11 +1,8 @@
 import * as React from 'react';
-import { Grid, GridItem, PageSection, Title } from '@patternfly/react-core';
 import { TargetView } from '@app/TargetView/TargetView';
 
-export const Dashboard = (props) => {
-
+export const Dashboard = () => {
   return (
     <TargetView pageTitle="Dashboard" allowDisconnect={true} compactSelect={false} />
   );
-
 }

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -10,7 +10,7 @@ export interface EventTemplate {
   provider: string;
 }
 
-export const EventTemplates = (props) => {
+export const EventTemplates = () => {
   const context = React.useContext(ServiceContext);
 
   const [templates, setTemplates] = React.useState([]);
@@ -43,11 +43,11 @@ export const EventTemplates = (props) => {
       )
       .subscribe(templates => setTemplates(templates));
     return () => sub.unsubscribe();
-  }, []);
+  }, [context.commandChannel]);
 
   React.useEffect(() => {
     context.commandChannel.sendMessage('list-event-templates');
-  }, []);
+  }, [context.commandChannel]);
 
   return(<>
     <Toolbar>

--- a/src/app/Events/Events.tsx
+++ b/src/app/Events/Events.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
-import { Card, CardBody, CardHeader, Tabs, Tab, TabsVariant, TabContent, Text, TextVariants } from '@patternfly/react-core';
+import { Card, CardBody, CardHeader, Tabs, Tab, Text, TextVariants } from '@patternfly/react-core';
 import { TargetView } from '@app/TargetView/TargetView';
 import { EventTemplates } from './EventTemplates';
 import { EventTypes } from './EventTypes';
 
-export const Events = (props) => {
+export const Events = () => {
   const [activeTab, setActiveTab] = React.useState(0);
 
   const handleTabSelect = (evt, idx) => {

--- a/src/app/Login/BasicAuthForm.tsx
+++ b/src/app/Login/BasicAuthForm.tsx
@@ -7,11 +7,11 @@ export const BasicAuthForm = (props: FormProps) => {
   const [username, setUsername] = React.useState('');
   const [password, setPassword] = React.useState('');
 
-  const handleUserChange = (evt, el) => {
+  const handleUserChange = (evt) => {
     setUsername(evt);
   }
 
-  const handlePasswordChange = (evt, el) => {
+  const handlePasswordChange = (evt) => {
     setPassword(evt);
   }
 

--- a/src/app/Login/BearerAuthForm.tsx
+++ b/src/app/Login/BearerAuthForm.tsx
@@ -6,7 +6,7 @@ export const BearerAuthForm = (props: FormProps) => {
 
   const [token, setToken] = React.useState('');
 
-  const handleTokenChange = (evt, el) => {
+  const handleTokenChange = (evt) => {
     setToken(evt);
   }
 

--- a/src/app/Login/FormProps.tsx
+++ b/src/app/Login/FormProps.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 export interface FormProps {
-  onSubmit(evt: any, token: string, authMethod: string): void;
+  onSubmit(evt: React.SyntheticEvent<HTMLInputElement>, token: string, authMethod: string): void;
 }

--- a/src/app/Login/Login.tsx
+++ b/src/app/Login/Login.tsx
@@ -1,24 +1,29 @@
 import * as React from 'react';
-import { Card, CardBody, CardHeader, CardFooter, PageSection, Text, TextInput, TextVariants, Title } from '@patternfly/react-core';
+import { Card, CardBody, CardHeader, CardFooter, PageSection, Title } from '@patternfly/react-core';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { BasicAuthForm, BasicAuthDescriptionText } from './BasicAuthForm';
 import { BearerAuthForm, BearerAuthDescriptionText } from './BearerAuthForm';
 
-export const Login = (props) => {
+export interface LoginProps {
+  onLoginSuccess: () => void;
+}
+
+export const Login: React.FunctionComponent<LoginProps> = (props) => {
   const context = React.useContext(ServiceContext);
 
   const [authMethod, setAuthMethod] = React.useState('Basic');
+  const onLoginSuccess = props.onLoginSuccess;
 
-  const checkAuth = (token: string, authMethod: string): void => {
+  const checkAuth = React.useCallback((token: string, authMethod: string): void => {
     if (authMethod === 'Basic') {
-      token = btoa(token);
+      token = window.btoa(token);
     } // else this is Bearer auth and the token is sent as-is
     context.api.checkAuth(token, authMethod).subscribe(v => {
       if (v) {
-        props.onLoginSuccess();
+        onLoginSuccess();
       }
     })
-  }
+  }, [onLoginSuccess, context.api]);
 
   const handleSubmit = (evt, token, authMethod) => {
     checkAuth(token, authMethod);
@@ -29,7 +34,7 @@ export const Login = (props) => {
     checkAuth('', 'Basic');
     const sub = context.api.getAuthMethod().subscribe(authMethod => setAuthMethod(authMethod));
     return () => sub.unsubscribe();
-  }, []);
+  }, [checkAuth, context.api]);
 
   return (
     <PageSection>

--- a/src/app/Notifications/NotificationCenter.tsx
+++ b/src/app/Notifications/NotificationCenter.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Alert, AlertActionCloseButton, AlertGroup, AlertVariant, Text, TextVariants } from '@patternfly/react-core';
 import { Notification, NotificationsContext } from './Notifications';
 
-export const NotificationCenter = (props) => {
+export const NotificationCenter = () => {
   const context = React.useContext(NotificationsContext);
 
   const [notifications, setNotifications] = React.useState([] as Notification[]);
@@ -18,9 +18,9 @@ export const NotificationCenter = (props) => {
   };
 
   const addNotification = (notification: Notification) => {
-    setNotifications([...notifications, notification]);
-    if (notification.timeout > 0) {
-      setTimeout(() => setNotifications(removeNotificationByKey(notifications, notification.key)), notification.timeout);
+    setNotifications(notifications => [...notifications, notification]);
+    if (notification?.timeout) {
+      window.setTimeout(() => setNotifications(removeNotificationByKey(notifications, notification.key)), notification.timeout);
     }
   };
 

--- a/src/app/Notifications/Notifications.tsx
+++ b/src/app/Notifications/Notifications.tsx
@@ -3,7 +3,7 @@ import { Observable, Subject } from 'rxjs';
 import { AlertVariant } from '@patternfly/react-core';
 import { nanoid } from 'nanoid';
 
-interface Notification {
+export interface Notification {
   key?: string;
   title: string;
   message?: string;
@@ -11,9 +11,9 @@ interface Notification {
   timeout?: number;
 }
 
-const DefaultNotificationTimeout = 15_000;
+export const DefaultNotificationTimeout = 15_000;
 
-class Notifications {
+export class Notifications {
 
   private readonly notifications = new Subject<Notification>();
 
@@ -49,8 +49,6 @@ class Notifications {
 
 }
 
-const NotificationsInstance = new Notifications();
+export const NotificationsInstance = new Notifications();
 
-const NotificationsContext = React.createContext(NotificationsInstance);
-
-export { Notification, DefaultNotificationTimeout, Notifications, NotificationsContext, NotificationsInstance };
+export const NotificationsContext = React.createContext(NotificationsInstance);

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -18,7 +18,7 @@ export class ApiService {
    }
 
   checkAuth(token: string, method: string): Observable<boolean> {
-    return fromFetch(`${this.authority}/auth`, {
+    return fromFetch(`${this.authority}/api/v1/auth`, {
       credentials: 'include',
       mode: 'cors',
       method: 'POST',
@@ -83,7 +83,7 @@ export class ApiService {
       combineLatest(this.getAuthMethod()),
       first(),
       flatMap(auths =>
-        fromFetch(`/recordings`, {
+        fromFetch(`/api/v1/recordings`, {
           credentials: 'include',
           mode: 'cors',
           body: payload,

--- a/src/app/Shared/Services/CommandChannel.service.tsx
+++ b/src/app/Shared/Services/CommandChannel.service.tsx
@@ -20,14 +20,14 @@ export class CommandChannel {
   constructor(apiSvc: ApiService, private readonly notifications: Notifications) {
     this.apiSvc = apiSvc;
 
-    fromFetch(`${this.apiSvc.authority}/clienturl`)
+    fromFetch(`${this.apiSvc.authority}/api/v1/clienturl`)
       .pipe(concatMap(resp => from(resp.json())))
       .subscribe(
         (url: any) => this.clientUrlSubject.next(url.clientUrl),
         (err: any) => this.logError('Client URL configuration', err)
       );
 
-    fromFetch(`${this.apiSvc.authority}/grafana_datasource_url`)
+    fromFetch(`${this.apiSvc.authority}/api/v1/grafana_datasource_url`)
       .pipe(concatMap(resp => from(resp.json())))
       .subscribe(
         (url: any) => this.grafanaDatasourceUrlSubject.next(url.grafanaDatasourceUrl),

--- a/src/app/Shared/Services/Services.tsx
+++ b/src/app/Shared/Services/Services.tsx
@@ -3,16 +3,13 @@ import { ApiService } from './Api.service';
 import { CommandChannel } from './CommandChannel.service';
 import { NotificationsInstance } from '@app/Notifications/Notifications';
 
-interface Services {
+export interface Services {
   api: ApiService;
   commandChannel: CommandChannel;
 }
 
 const api = new ApiService();
 const commandChannel = new CommandChannel(api, NotificationsInstance);
+export const defaultServices: Services = { api, commandChannel };
 
-const defaultServices: Services = { api, commandChannel };
-
-const ServiceContext: React.Context<Services> = React.createContext(defaultServices);
-
-export { Services, ServiceContext, defaultServices };
+export const ServiceContext: React.Context<Services> = React.createContext(defaultServices);

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { distinctUntilChanged, filter, first } from 'rxjs/operators';
-import { Card, CardBody, CardHeader, Grid, GridItem, PageSection, Select, SelectOption, SelectVariant, Text, TextVariants, Title } from '@patternfly/react-core';
+import { Card, CardBody, CardHeader, Grid, GridItem, Select, SelectOption, SelectVariant, Text, TextVariants } from '@patternfly/react-core';
 import { ContainerNodeIcon } from '@patternfly/react-icons';
 import { ServiceContext } from '@app/Shared/Services/Services';
 
@@ -15,7 +15,7 @@ interface Target {
   port: number;
 }
 
-export const TargetSelect = (props: TargetSelectProps) => {
+export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) => {
   const context = React.useContext(ServiceContext);
   const [selected, setSelected] = React.useState('');
   const [targets, setTargets] = React.useState([]);
@@ -24,19 +24,19 @@ export const TargetSelect = (props: TargetSelectProps) => {
   React.useEffect(() => {
     const sub = context.commandChannel.onResponse('scan-targets').subscribe(msg => setTargets(msg.payload));
     return () => sub.unsubscribe();
-  }, []);
+  }, [context.commandChannel]);
 
   React.useEffect(() => {
     const sub = context.commandChannel.onResponse('connect').pipe(filter(m => m.status === 0)).subscribe(m => setSelected(m.payload));
     return () => sub.unsubscribe();
-  }, []);
+  }, [context.commandChannel]);
 
   React.useEffect(() => {
     const sub = context.commandChannel.isReady()
       .pipe(filter(v => !!v), first())
       .subscribe(() => context.commandChannel.sendMessage('scan-targets', []));
     return () => sub.unsubscribe();
-  }, []);
+  }, [context.commandChannel]);
 
   React.useEffect(() => {
     const sub = context.commandChannel.onResponse('is-connected').pipe(distinctUntilChanged()).subscribe(connection => {
@@ -48,14 +48,14 @@ export const TargetSelect = (props: TargetSelectProps) => {
       }
     });
     return () => sub.unsubscribe();
-  }, []);
+  }, [context.commandChannel]);
 
   React.useEffect(() => {
-    const sub = context.commandChannel.isReady().pipe(filter(v => v!!), first()).subscribe(() => {
+    const sub = context.commandChannel.isReady().pipe(filter(v => !!v), first()).subscribe(() => {
       context.commandChannel.sendMessage('is-connected');
     });
     return () => sub.unsubscribe();
-  }, []);
+  }, [context.commandChannel]);
 
   const connect = (target: Target) => {
     context.commandChannel.sendMessage('connect', [ `${target.connectUrl}:${target.port}` ]);

--- a/src/app/TargetView/TargetView.tsx
+++ b/src/app/TargetView/TargetView.tsx
@@ -3,14 +3,13 @@ import { TargetSelect } from '@app/TargetSelect/TargetSelect';
 import { BreadcrumbPage, BreadcrumbTrail } from '@app/BreadcrumbPage/BreadcrumbPage';
 
 interface TargetViewProps {
-  children?: any;
   pageTitle: string;
   compactSelect?: boolean;
   allowDisconnect?: boolean;
   breadcrumbs?: BreadcrumbTrail[];
 }
 
-export const TargetView = (props: TargetViewProps) => {
+export const TargetView: React.FunctionComponent<TargetViewProps> = (props) => {
   return (<>
     <BreadcrumbPage pageTitle={props.pageTitle} breadcrumbs={props.breadcrumbs}>
       <TargetSelect isCompact={props.compactSelect == null ? true : props.compactSelect} allowDisconnect={props.allowDisconnect || false} isFilled={false} />

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import { Route, RouteComponentProps, Switch } from 'react-router-dom';
-import { Alert, PageSection } from '@patternfly/react-core';
 import { filter } from 'rxjs/operators';
-import { DynamicImport } from '@app/DynamicImport';
 import { accessibleRouteChangeHandler } from '@app/utils/utils';
 import { NotFound } from '@app/NotFound/NotFound';
 import { useDocumentTitle } from '@app/utils/useDocumentTitle';
@@ -119,7 +117,7 @@ const AppRoutes = () => {
       .isConnected()
       .subscribe(isConnected => setAvailableRoutes(getAvailableRoutes(isConnected)));
     return () => sub.unsubscribe();
-  }, []);
+  }, [context.commandChannel]);
 
   React.useEffect(() => {
     const sub = context.commandChannel
@@ -127,7 +125,7 @@ const AppRoutes = () => {
       .pipe(filter(v => !v))
       .subscribe(() => setAuthenticated(false));
     return () => sub.unsubscribe();
-  }, []);
+  }, [context.commandChannel]);
 
   return (
     <LastLocationProvider>


### PR DESCRIPTION
Based on top of #66 

This fixes most React linting issues listed by `npm run lint`. Most are generally cosmetic, ex. removing unused imports and variables, but others are potential bug fixes. Several fixes include adding new dependencies to `React.useEffect` hooks to ensure that the hook callbacks are always run when any potential dependency value changes, although in many cases this value is the `context.commandChannel`, which would be essentially static for the lifetime of the application. One related change is the `AppLayout` change from `useRouteMatch` to `useLocation` - `useRouteMatch` is actually a React hook which should not be called in a utility function as was done previously.

There are unapplied linting fixes suggested for the `CommandChannel`. These have to do with the payload types of `ResponseMessage`s. I need to come up with a better way to define the types here, so I'll add a commit to this PR when I have a solution. The rest of these changes were simple enough, so I went ahead with them first.