### PR TITLE
Connectionless API

### DIFF
--- a/src/app/RecordingList/ArchivedRecordingsList.tsx
+++ b/src/app/RecordingList/ArchivedRecordingsList.tsx
@@ -37,14 +37,14 @@ export const ArchivedRecordingsList = (props) => {
     recordings.forEach((r: Recording, idx) => {
       if (checkedIndices.includes(idx)) {
         handleRowCheck(false, idx);
-        context.commandChannel.sendMessage('delete-saved', [ r.name ]);
+        context.commandChannel.sendControlMessage('delete-saved', [ r.name ]);
       }
     });
-    context.commandChannel.sendMessage('list-saved');
+    context.commandChannel.sendControlMessage('list-saved');
   };
 
   React.useEffect(() => {
-    const sub = context.commandChannel.onResponse('save').subscribe(() => context.commandChannel.sendMessage('list-saved'));
+    const sub = context.commandChannel.onResponse('save').subscribe(() => context.commandChannel.sendControlMessage('list-saved'));
     return () => sub.unsubscribe();
   });
 
@@ -59,8 +59,8 @@ export const ArchivedRecordingsList = (props) => {
   }, []);
 
   React.useEffect(() => {
-    context.commandChannel.sendMessage('list-saved');
-    const id = setInterval(() => context.commandChannel.sendMessage('list-saved'), 5000);
+    context.commandChannel.sendControlMessage('list-saved');
+    const id = setInterval(() => context.commandChannel.sendControlMessage('list-saved'), 5000);
     return () => clearInterval(id);
   }, []);
 

--- a/src/app/Shared/Services/CommandChannel.service.tsx
+++ b/src/app/Shared/Services/CommandChannel.service.tsx
@@ -1,6 +1,6 @@
 import { from, Subject, BehaviorSubject, Observable, ReplaySubject, combineLatest } from 'rxjs';
 import { fromFetch } from 'rxjs/fetch';
-import { concatMap, distinctUntilChanged, filter, first, map, tap } from 'rxjs/operators';
+import { concatMap, filter, first, map, tap } from 'rxjs/operators';
 import { ApiService } from './Api.service';
 import { Notifications } from '@app/Notifications/Notifications';
 import { nanoid } from 'nanoid';
@@ -11,10 +11,11 @@ export class CommandChannel {
   private readonly apiSvc: ApiService;
   private readonly messages = new Subject<ResponseMessage<any>>();
   private readonly ready = new BehaviorSubject<boolean>(false);
-  private readonly connected = new ReplaySubject<boolean>(1);
   private readonly archiveEnabled = new ReplaySubject<boolean>(1);
   private readonly clientUrlSubject = new ReplaySubject<string>(1);
   private readonly grafanaDatasourceUrlSubject = new ReplaySubject<string>(1);
+  private readonly grafanaDashboardUrlSubject = new ReplaySubject<string>(1);
+  private readonly targetSubject = new ReplaySubject<string>(1);
   private pingTimer: number = -1;
 
   constructor(apiSvc: ApiService, private readonly notifications: Notifications) {
@@ -34,25 +35,22 @@ export class CommandChannel {
         (err: any) => this.logError('Grafana Datasource configuration', err)
       );
 
-    this.onResponse('disconnect').pipe(
-      filter(msg => msg.status !== 0),
-    ).subscribe(msg => this.logError('Command failure', msg));
+    fromFetch(`${this.apiSvc.authority}/api/v1/grafana_dashboard_url`)
+      .pipe(concatMap(resp => from(resp.json())))
+      .subscribe(
+        (url: any) => this.grafanaDashboardUrlSubject.next(url.grafanaDashboardUrl),
+        (err: any) => this.logError('Grafana Dashboard configuration', err)
+      );
 
     this.onResponse('list-saved').pipe(
       first(),
       map(msg => msg.status === 0)
     ).subscribe(listSavedEnabled => this.archiveEnabled.next(listSavedEnabled));
 
-    // FIXME handle the case of a failed 'connect' command
-    this.onResponse('is-connected').subscribe(c => this.connected.next(c.status === 0 && c.payload !== 'false'));
-    this.onResponse('disconnect').pipe(filter(m => m.status === 0)).subscribe(() => this.connected.next(false));
-    this.onResponse('connect').pipe(filter(m => m.status === 0)).subscribe(() => this.connected.next(true));
-
     this.isReady().pipe(
       filter(ready => !!ready)
     ).subscribe(ready => {
-      this.sendMessage('is-connected');
-      this.sendMessage('list-saved');
+      this.sendControlMessage('list-saved');
     });
 
     this.clientUrl().pipe(
@@ -99,7 +97,7 @@ export class CommandChannel {
 
         this.ws.addEventListener('open', () => {
           this.pingTimer = window.setInterval(() => {
-            this.sendMessage('ping');
+            this.sendControlMessage('ping');
           }, 10 * 1000);
           this.ready.next(true);
         });
@@ -117,15 +115,15 @@ export class CommandChannel {
   }
 
   isReady(): Observable<boolean> {
-    return this.ready.asObservable().pipe(distinctUntilChanged());
+    return this.ready.asObservable();
   }
 
   isConnected(): Observable<boolean> {
-    return this.connected.asObservable().pipe(distinctUntilChanged());
+    return this.target().pipe(map(t => !!t));
   }
 
   isArchiveEnabled(): Observable<boolean> {
-    return this.archiveEnabled.asObservable().pipe(distinctUntilChanged());
+    return this.archiveEnabled.asObservable();
   }
 
   addCloseHandler(handler: () => void): void {
@@ -134,7 +132,16 @@ export class CommandChannel {
     }
   }
 
-  sendMessage(command: string, args: string[] = [], id: string = this.createMessageId()): Observable<string> {
+  setTarget(targetId: string): void {
+    this.targetSubject.next(targetId);
+  }
+
+  target(): Observable<string> {
+    return this.targetSubject.asObservable();
+  }
+
+  // "control" messages, which do not operate upon a Target JVM
+  sendControlMessage(command: string, args: string[] = [], id: string = this.createMessageId()): Observable<string> {
     const subj = new Subject<string>();
     this.ready.pipe(
       first(),
@@ -143,11 +150,30 @@ export class CommandChannel {
       if (!!i && this.ws) {
         this.ws.send(JSON.stringify({ id, command, args }));
       } else if (this.ws) {
+        this.logError('Attempted to send control message when command channel was not ready', { id, command, args });
+      } else {
+        this.logError('Attempted to send control message when command channel was not initialized', { id, command, args });
+      }
+      subj.next(i);
+    });
+    return subj.asObservable();
+  }
+
+  // "targeted" messages, ie those which operate upon a specific Target JVM
+  sendMessage(command: string, args: string[] = [], id: string = this.createMessageId()): Observable<string> {
+    const subj = new Subject<string>();
+    combineLatest(this.target(), this.ready.pipe(
+      first(),
+      map(ready => ready ? id : '')
+    )).subscribe(([target, id]) => {
+      if (!!id && this.ws) {
+        this.ws.send(JSON.stringify({ id, command, args: [target, ...args] }));
+      } else if (this.ws) {
         this.logError('Attempted to send message when command channel was not ready', { id, command, args });
       } else {
         this.logError('Attempted to send message when command channel was not initialized', { id, command, args });
       }
-      subj.next(i);
+      subj.next(id);
     });
     return subj.asObservable();
   }


### PR DESCRIPTION
Rebased and reopened version of #80, after `react` branch merge to `master`.

The goal here is simply to patch the React client to work with ContainerJFR's upcoming non-connection-oriented/connectionless API changes ( https://github.com/rh-jmc-team/container-jfr/pull/161 ). It is intentionally minimal and provides support for the backend changes only, not changing any client layout or behaviour.

The `CommandChannel` front-end "service" object gains an RxJS Subject which maintains a piece of state representing the "connected" target JVM, emulating the previous stateful connection-oriented API. This is just to maintain compatibility with the rest of the structure of the React client and will be removed at a later time, so that the web application itself also works in a "connectionless" manner.

Otherwise, this simply adds a frontend distinction between messages sent being "control" messages or not. "Control" messages simply being those that do not specify any `targetId` - they perform some kind of "control" operation on the ContainerJFR backend instance itself (ex. delete a saved recording in ContainerJFR disk space, ping the instance). Other, non-control messages do specify a `targetId`, and perform operations upon a specific JVM target (ex. start/stop recording, delete recording, list recordings - all occur on a specific JVM). This distinction will also likely be refactored or removed in the future when the various components are modified to work in a connectionless manner.