### PR TITLE
Add target list refresh button

### DIFF
--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -19,9 +19,13 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
   const [selected, setSelected] = React.useState('');
   const [targets, setTargets] = React.useState([]);
   const [expanded, setExpanded] = React.useState(false);
+  const [isLoading, setLoading] = React.useState(true);
 
   React.useEffect(() => {
-    const sub = context.commandChannel.onResponse('scan-targets').pipe(map(msg => msg.payload)).subscribe(setTargets);
+    const sub = context.commandChannel.onResponse('scan-targets').pipe(map(msg => msg.payload)).subscribe(targets => {
+      setTargets(targets);
+      setLoading(false);
+    });
     return () => sub.unsubscribe();
   }, [context.commandChannel]);
 
@@ -38,6 +42,7 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
   }, [context.commandChannel]);
 
   const refreshTargetList = () => {
+    setLoading(true);
     context.commandChannel.sendControlMessage('scan-targets')
   };
 
@@ -63,7 +68,12 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
                 </Text>
               </CardHeaderMain>
               <CardActions>
-                <Button onClick={refreshTargetList} variant="control" icon={<Spinner2Icon />} />
+                <Button
+                  isDisabled={isLoading}
+                  onClick={refreshTargetList}
+                  variant="control"
+                  icon={<Spinner2Icon />}
+                />
               </CardActions>
             </CardHeader>
             <CardBody>
@@ -73,6 +83,7 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
                 selections={selected}
                 onSelect={onSelect}
                 onToggle={setExpanded}
+                isDisabled={isLoading}
                 isOpen={expanded}
                 aria-label="Select Input"
               >

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ServiceContext } from '@app/Shared/Services/Services';
-import { Card, CardBody, CardHeader, Grid, GridItem, Select, SelectOption, SelectVariant, Text, TextVariants } from '@patternfly/react-core';
-import { ContainerNodeIcon } from '@patternfly/react-icons';
+import { Button, Card, CardActions, CardBody, CardHeader, CardHeaderMain, Grid, GridItem, Select, SelectOption, SelectVariant, Text, TextVariants } from '@patternfly/react-core';
+import { ContainerNodeIcon, Spinner2Icon } from '@patternfly/react-icons';
 import { filter, first, map } from 'rxjs/operators';
 
 export interface TargetSelectProps {
@@ -28,7 +28,7 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
   React.useEffect(() => {
     const sub = context.commandChannel.isReady()
       .pipe(filter(v => !!v), first())
-      .subscribe(() => context.commandChannel.sendControlMessage('scan-targets'));
+      .subscribe(refreshTargetList);
     return () => sub.unsubscribe();
   }, [context.commandChannel]);
 
@@ -36,6 +36,10 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
     const sub = context.commandChannel.target().subscribe(setSelected);
     return () => sub.unsubscribe();
   }, [context.commandChannel]);
+
+  const refreshTargetList = () => {
+    context.commandChannel.sendControlMessage('scan-targets')
+  };
 
   const onSelect = (evt, selection, isPlaceholder) => {
     if (isPlaceholder) {
@@ -53,9 +57,14 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
         <GridItem span={props.isCompact ? 4 : 8}>
           <Card>
             <CardHeader>
-              <Text component={TextVariants.h4}>
-                Target JVM
-              </Text>
+              <CardHeaderMain>
+                <Text component={TextVariants.h4}>
+                  Target JVM
+                </Text>
+              </CardHeaderMain>
+              <CardActions>
+                <Button onClick={refreshTargetList} variant="control" icon={<Spinner2Icon />} />
+              </CardActions>
             </CardHeader>
             <CardBody>
               <Select


### PR DESCRIPTION
This simply adds a button to the Target Select component card's action area, which sends a scan-targets command when clicked. The button and the selection dropdown are disabled in between the message being sent and a response received. The selection dropdown is reactively updated as usual when a response is received.