### PR TITLE
Remove timed background command channel ping

### DIFF
--- a/src/app/Shared/Services/CommandChannel.service.tsx
+++ b/src/app/Shared/Services/CommandChannel.service.tsx
@@ -17,7 +17,6 @@ export class CommandChannel {
   private readonly grafanaDatasourceUrlSubject = new ReplaySubject<string>(1);
   private readonly grafanaDashboardUrlSubject = new ReplaySubject<string>(1);
   private readonly targetSubject = new ReplaySubject<string>(1);
-  private pingTimer = -1;
 
   constructor(apiSvc: ApiService, private readonly notifications: Notifications) {
     this.apiSvc = apiSvc;
@@ -90,16 +89,12 @@ export class CommandChannel {
           protocol: subprotocol,
           openObserver: {
             next: () => {
-              this.pingTimer = window.setInterval(() => {
-                this.sendControlMessage('ping');
-              }, 10 * 1000);
               this.ready.next(true);
             }
           },
           closeObserver: {
             next: () => {
               this.ready.next(false);
-              window.clearInterval(this.pingTimer);
               this.notifications.info('WebSocket connection lost');
             }
           }


### PR DESCRIPTION
The periodic ping was initially used for development testing to check
whether communication errors were due to closed connections or the
backend not responding, but this is no longer a common concern and so
the ping serves no practical purpose. It should be removed to prevent it
from clogging backend logs.