### PR TITLE
enable sidebar to autohide on narrow screen

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -54,7 +54,8 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
   };
 
   const Navigation = (
-    <Nav id="nav-primary-simple" theme="dark" variant="default">
+    <Nav id="nav-primary-simple" theme="dark" variant="default" 
+        onSelect={(selected) => {if(isMobileView) setIsNavOpenMobile(false)}}>
       <NavList id="nav-list-simple">
         {routes.map((route, idx) => route.label && (
             <NavItem key={`${route.label}-${idx}`} id={`${route.label}-${idx}`} isActive={isActiveRoute(route)}>

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -29,6 +29,9 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
   const onPageResize = (props: { mobileView: boolean; windowSize: number }) => {
     setIsMobileView(props.mobileView);
   };
+  const mobileOnSelect = (selected) => {
+    if(isMobileView) setIsNavOpenMobile(false)
+  };
   const Header = (
     <PageHeader
       logo="ContainerJFR"
@@ -54,8 +57,7 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
   };
 
   const Navigation = (
-    <Nav id="nav-primary-simple" theme="dark" variant="default" 
-        onSelect={(selected) => {if(isMobileView) setIsNavOpenMobile(false)}}>
+    <Nav id="nav-primary-simple" theme="dark" variant="default" onSelect={mobileOnSelect}>
       <NavList id="nav-list-simple">
         {routes.map((route, idx) => route.label && (
             <NavItem key={`${route.label}-${idx}`} id={`${route.label}-${idx}`} isActive={isActiveRoute(route)}>


### PR DESCRIPTION
When the window is resized to a vertical view (narrow width) the sidebar starts covering the page (overlay), and when a page on the menu is chosen the bar now closes automatically (given nothing can be done with the bar open).
