### PR TITLE
Call health endpoint

### DIFF
--- a/src/app/Shared/Services/CommandChannel.service.tsx
+++ b/src/app/Shared/Services/CommandChannel.service.tsx
@@ -46,7 +46,7 @@ export class CommandChannel {
         (url: any) => 
           {this.grafanaDatasourceUrlSubject.next(url[0].grafanaDatasourceUrl);
             this.grafanaDashboardUrlSubject.next(url[1].grafanaDashboardUrl);},
-        err => this.logError('Grafana configuration', err)
+        err => this.logError('Grafana configuration not found', err)
       );
     
     this.onResponse('list-saved').pipe(

--- a/src/app/Shared/Services/CommandChannel.service.tsx
+++ b/src/app/Shared/Services/CommandChannel.service.tsx
@@ -37,18 +37,18 @@ export class CommandChannel {
       .pipe(
         concatMap(resp => from(resp.json())), 
         concatMap((jsonResp: any) => {
-          if ((jsonResp.dashboardAvailable == true) && (jsonResp.datasourceAvailable == true)) {
-            return forkJoin([getDatasourceURL, getDashboardURL])
+          if (jsonResp.dashboardAvailable && jsonResp.datasourceAvailable) {
+            return forkJoin([getDatasourceURL, getDashboardURL]);
           } else {
-            var errMessage = "";
-            if (jsonResp.dashboardAvailable == false) {
-              errMessage = "dashboard URL "
+            const missing: string[] = [];
+            if (!jsonResp.dashboardAvailable) {
+              missing.push('dashboard URL');
             }
-            if (jsonResp.datasourceAvailable == false) {
-              errMessage = errMessage.concat(
-                (errMessage == "")? "datasource URL " : ", datasource URL ")
+            if (!jsonResp.datasourceAvailable) {
+              missing.push('datasource URL');
             }
-            return throwError(errMessage.concat('missing'));
+            const message = missing.join(', ') + ' unavailable';
+            return throwError(message);
           }}))
       .subscribe(
         (url: any) => {

--- a/src/app/Shared/Services/CommandChannel.service.tsx
+++ b/src/app/Shared/Services/CommandChannel.service.tsx
@@ -40,12 +40,21 @@ export class CommandChannel {
           if ((jsonResp.dashboardAvailable == true) && (jsonResp.datasourceAvailable == true)) {
             return forkJoin([getDatasourceURL, getDashboardURL])
           } else {
-              return throwError(new Error('ULRs unavailable'));
+            var errMessage = "";
+            if (jsonResp.dashboardAvailable == false) {
+              errMessage = "dashboard URL "
+            }
+            if (jsonResp.datasourceAvailable == false) {
+              errMessage = errMessage.concat(
+                (errMessage == "")? "datasource URL " : ", datasource URL ")
+            }
+            return throwError(errMessage.concat('missing'));
           }}))
       .subscribe(
-        (url: any) => 
-          {this.grafanaDatasourceUrlSubject.next(url[0].grafanaDatasourceUrl);
-            this.grafanaDashboardUrlSubject.next(url[1].grafanaDashboardUrl);},
+        (url: any) => {
+          this.grafanaDatasourceUrlSubject.next(url[0].grafanaDatasourceUrl);
+          this.grafanaDashboardUrlSubject.next(url[1].grafanaDashboardUrl);
+        },
         err => this.logError('Grafana configuration not found', err)
       );
     


### PR DESCRIPTION
Request health endpoint to determine if the Grafana configuration is set up, and only if it is then request URLs. Unified error message when configuration is not present. 