### PR TITLE
Support Backend Changes to `upload-recording` that Assumes Datasource URL

### DIFF
--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -308,7 +308,7 @@ export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = 
       notifications.info('Upload Started', `Recording "${props.recording.name}" uploading...`);
       const id = context.commandChannel.createMessageId();
       setUploadIds(ids => [...ids, id]);
-      context.commandChannel.sendMessage('upload-recording', [ props.recording.name, `${url}/load` ], id);
+      context.commandChannel.sendMessage('upload-recording', [ props.recording.name ], id);
     });
   };
 


### PR DESCRIPTION
Fixes #86.

I guess something worth noting is that before, the web client would append `/load` to the datasource URL env var, but now, the command just uses the env var directly. So a previous env var of `http://localhost:8080` should be changed to `http://localhost:8080/load`.
