### PR TITLE
Replace Command Channel usage with HTTP REST APIs

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2020 Red Hat, Inc.
- * 
+ *
  * The Universal Permissive License (UPL), Version 1.0
- * 
+ *
  * Subject to the condition set forth below, permission is hereby granted to any
  * person obtaining a copy of this software, associated documentation and/or data
  * (collectively the "Software"), free of charge and under any and all copyright
@@ -10,23 +10,23 @@
  * licensable by each licensor hereunder covering either (i) the unmodified
  * Software as contributed to or provided by such licensor, or (ii) the Larger
  * Works (as defined below), to deal in both
- * 
+ *
  * (a) the Software, and
  * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
  * one is included with the Software (each a "Larger Work" to which the Software
  * is contributed by such licensors),
- * 
+ *
  * without restriction, including without limitation the rights to copy, create
  * derivative works of, display, perform, and distribute the Software and make,
  * use, sell, offer for sale, import, export, have made, and have sold the
  * Software and the Larger Work(s), and to sublicense the foregoing rights on
  * either these or other terms.
- * 
+ *
  * This license is subject to the following condition:
  * The above copyright notice and either this complete permission notice or at
  * a minimum a reference to the UPL must be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -38,7 +38,6 @@
 import * as React from 'react';
 import { NotificationCenter } from '@app/Notifications/NotificationCenter';
 import { IAppRoute, routes } from '@app/routes';
-import { ServiceContext } from '@app/Shared/Services/Services';
 import { Nav, NavItem, NavList, Page, PageHeader, PageSidebar, SkipToContent } from '@patternfly/react-core';
 import { NavLink, matchPath, useLocation } from 'react-router-dom';
 
@@ -47,7 +46,6 @@ interface IAppLayout {
 }
 
 const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
-  const context = React.useContext(ServiceContext);
   const logoProps = {
     href: '/',
     target: '_blank'

--- a/src/app/CreateRecording/CreateRecording.tsx
+++ b/src/app/CreateRecording/CreateRecording.tsx
@@ -66,40 +66,21 @@ const Comp: React.FunctionComponent< RouteComponentProps<{}, StaticContext, Crea
   const [activeTab, setActiveTab] = React.useState(0);
 
   const handleCreateRecording = (recordingName: string, events: string, duration?: number): void => {
-    const form = new FormData();
-    form.append('recordingName', recordingName);
-    form.append('events', events);
-    if (!!duration && duration > 0) {
-      form.append('duration', String(duration));
-    }
     context.commandChannel.target().pipe(
-      concatMap(target => context.api.sendRequest(`targets/${encodeURIComponent(target)}/recordings`, {
-        method: 'POST',
-        body: form,
-      })),
-      first(),
-    ).subscribe(resp => {
-      if (200 <= resp.status && resp.status < 300) {
-        notifications.success('Recording created');
+      concatMap(targetId => context.api.createRecording(targetId, { recordingName, events, duration }))
+    ).subscribe(success => {
+      if (success) {
         history.push('/recordings');
-      } else {
-        notifications.danger(`Request failed (Status ${resp.status})`, resp.statusText)
       }
     });
   };
 
   const handleCreateSnapshot = (): void => {
     context.commandChannel.target().pipe(
-      concatMap(target => context.api.sendRequest(`targets/${encodeURIComponent(target)}/snapshot`, {
-        method: 'POST',
-      })),
-      first(),
-    ).subscribe(resp => {
-      if (200 <= resp.status && resp.status < 300) {
-        notifications.success('Recording created');
+      concatMap(targetId => context.api.createSnapshot(targetId))
+    ).subscribe(success => {
+      if (success) {
         history.push('/recordings');
-      } else {
-        notifications.danger(`Request failed (Status ${resp.status})`, resp.statusText)
       }
     });
   };

--- a/src/app/CreateRecording/CreateRecording.tsx
+++ b/src/app/CreateRecording/CreateRecording.tsx
@@ -66,23 +66,21 @@ const Comp: React.FunctionComponent< RouteComponentProps<{}, StaticContext, Crea
   const [activeTab, setActiveTab] = React.useState(0);
 
   const handleCreateRecording = (recordingName: string, events: string, duration?: number): void => {
-    context.target.target().pipe(
-      concatMap(targetId => context.api.createRecording(targetId, { recordingName, events, duration }))
-    ).subscribe(success => {
-      if (success) {
-        history.push('/recordings');
-      }
-    });
+    context.api.createRecording({ recordingName, events, duration })
+      .subscribe(success => {
+        if (success) {
+          history.push('/recordings');
+        }
+      });
   };
 
   const handleCreateSnapshot = (): void => {
-    context.target.target().pipe(
-      concatMap(targetId => context.api.createSnapshot(targetId))
-    ).subscribe(success => {
-      if (success) {
-        history.push('/recordings');
-      }
-    });
+    context.api.createSnapshot()
+      .subscribe(success => {
+        if (success) {
+          history.push('/recordings');
+        }
+      });
   };
 
   return (

--- a/src/app/CreateRecording/CreateRecording.tsx
+++ b/src/app/CreateRecording/CreateRecording.tsx
@@ -39,6 +39,7 @@ import * as React from 'react';
 import { NotificationsContext } from '@app/Notifications/Notifications';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { TargetView } from '@app/TargetView/TargetView';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { Card, CardBody, Tab, Tabs } from '@patternfly/react-core';
 import { StaticContext } from 'react-router';
 import { RouteComponentProps, useHistory, withRouter } from 'react-router-dom';
@@ -62,25 +63,30 @@ const Comp: React.FunctionComponent< RouteComponentProps<{}, StaticContext, Crea
   const context = React.useContext(ServiceContext);
   const notifications = React.useContext(NotificationsContext);
   const history = useHistory();
+  const addSubscription = useSubscriptions();
 
   const [activeTab, setActiveTab] = React.useState(0);
 
   const handleCreateRecording = (recordingName: string, events: string, duration?: number): void => {
-    context.api.createRecording({ recordingName, events, duration })
+    addSubscription(
+      context.api.createRecording({ recordingName, events, duration })
       .subscribe(success => {
         if (success) {
           history.push('/recordings');
         }
-      });
+      })
+    );
   };
 
   const handleCreateSnapshot = (): void => {
-    context.api.createSnapshot()
+    addSubscription(
+      context.api.createSnapshot()
       .subscribe(success => {
         if (success) {
           history.push('/recordings');
         }
-      });
+      })
+    );
   };
 
   return (

--- a/src/app/CreateRecording/CreateRecording.tsx
+++ b/src/app/CreateRecording/CreateRecording.tsx
@@ -66,7 +66,7 @@ const Comp: React.FunctionComponent< RouteComponentProps<{}, StaticContext, Crea
   const [activeTab, setActiveTab] = React.useState(0);
 
   const handleCreateRecording = (recordingName: string, events: string, duration?: number): void => {
-    context.commandChannel.target().pipe(
+    context.target.target().pipe(
       concatMap(targetId => context.api.createRecording(targetId, { recordingName, events, duration }))
     ).subscribe(success => {
       if (success) {
@@ -76,7 +76,7 @@ const Comp: React.FunctionComponent< RouteComponentProps<{}, StaticContext, Crea
   };
 
   const handleCreateSnapshot = (): void => {
-    context.commandChannel.target().pipe(
+    context.target.target().pipe(
       concatMap(targetId => context.api.createSnapshot(targetId))
     ).subscribe(success => {
       if (success) {

--- a/src/app/CreateRecording/CreateRecording.tsx
+++ b/src/app/CreateRecording/CreateRecording.tsx
@@ -36,14 +36,13 @@
  * SOFTWARE.
  */
 import * as React from 'react';
-import { NotificationsContext } from '@app/Notifications/Notifications';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { TargetView } from '@app/TargetView/TargetView';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { Card, CardBody, Tab, Tabs } from '@patternfly/react-core';
 import { StaticContext } from 'react-router';
 import { RouteComponentProps, useHistory, withRouter } from 'react-router-dom';
-import { concatMap, filter, first, map } from 'rxjs/operators';
+import { first } from 'rxjs/operators';
 import { CustomRecordingForm } from './CustomRecordingForm';
 import { SnapshotRecordingForm } from './SnapshotRecordingForm';
 
@@ -61,7 +60,6 @@ export interface EventTemplate {
 
 const Comp: React.FunctionComponent< RouteComponentProps<{}, StaticContext, CreateRecordingProps>> = (props) => {
   const context = React.useContext(ServiceContext);
-  const notifications = React.useContext(NotificationsContext);
   const history = useHistory();
   const addSubscription = useSubscriptions();
 

--- a/src/app/CreateRecording/CreateRecording.tsx
+++ b/src/app/CreateRecording/CreateRecording.tsx
@@ -79,7 +79,6 @@ const Comp: React.FunctionComponent< RouteComponentProps<{}, StaticContext, Crea
       })),
       first(),
     ).subscribe(resp => {
-      console.log({ resp });
       if (200 <= resp.status && resp.status < 300) {
         notifications.success('Recording created');
         history.push('/recordings');
@@ -96,7 +95,6 @@ const Comp: React.FunctionComponent< RouteComponentProps<{}, StaticContext, Crea
       })),
       first(),
     ).subscribe(resp => {
-      console.log({ resp });
       if (200 <= resp.status && resp.status < 300) {
         notifications.success('Recording created');
         history.push('/recordings');

--- a/src/app/CreateRecording/CreateRecording.tsx
+++ b/src/app/CreateRecording/CreateRecording.tsx
@@ -70,6 +70,7 @@ const Comp: React.FunctionComponent< RouteComponentProps<{}, StaticContext, Crea
   const handleCreateRecording = (recordingName: string, events: string, duration?: number): void => {
     addSubscription(
       context.api.createRecording({ recordingName, events, duration })
+      .pipe(first())
       .subscribe(success => {
         if (success) {
           history.push('/recordings');
@@ -81,6 +82,7 @@ const Comp: React.FunctionComponent< RouteComponentProps<{}, StaticContext, Crea
   const handleCreateSnapshot = (): void => {
     addSubscription(
       context.api.createSnapshot()
+      .pipe(first())
       .subscribe(success => {
         if (success) {
           history.push('/recordings');

--- a/src/app/CreateRecording/CustomRecordingForm.tsx
+++ b/src/app/CreateRecording/CustomRecordingForm.tsx
@@ -118,7 +118,8 @@ export const CustomRecordingForm = (props) => {
   };
 
   React.useEffect(() => {
-    context.target.target().pipe(concatMap(target => context.api.doGet<EventTemplate[]>(`targets/${encodeURIComponent(target)}/templates`))).subscribe(setTemplates);
+    const sub = context.target.target().pipe(concatMap(target => context.api.doGet<EventTemplate[]>(`targets/${encodeURIComponent(target)}/templates`))).subscribe(setTemplates);
+    return () => sub.unsubscribe();
   }, []);
 
   React.useEffect(() => {

--- a/src/app/CreateRecording/CustomRecordingForm.tsx
+++ b/src/app/CreateRecording/CustomRecordingForm.tsx
@@ -41,7 +41,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { ActionGroup, Button, Checkbox, Form, FormGroup, FormSelect, FormSelectOption, FormSelectOptionGroup, Split, SplitItem, Text, TextArea, TextInput, TextVariants, Tooltip, TooltipPosition, ValidatedOptions } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { useHistory } from 'react-router-dom';
-import { concatMap, filter, map } from 'rxjs/operators';
+import { concatMap } from 'rxjs/operators';
 import { EventTemplate } from './CreateRecording';
 
 export interface CustomRecordingFormProps {
@@ -64,7 +64,7 @@ export const CustomRecordingForm = (props) => {
   const [durationUnit, setDurationUnit] = React.useState(1);
   const [templates, setTemplates] = React.useState([] as EventTemplate[]);
   const [template, setTemplate] = React.useState(props.template || props?.location?.state?.template ||  '');
-  const [templateType, setTemplateType] = React.useState(props.templateType || props?.location?.state?.templateType || '');
+  const [templateType] = React.useState(props.templateType || props?.location?.state?.templateType || '');
   const [eventSpecifiers, setEventSpecifiers] = React.useState(props?.eventSpecifiers?.join(' ') || '');
   const [eventsValid, setEventsValid] = React.useState((!!props.template || !!props?.location?.state?.template) ? ValidatedOptions.success : ValidatedOptions.default);
 

--- a/src/app/CreateRecording/CustomRecordingForm.tsx
+++ b/src/app/CreateRecording/CustomRecordingForm.tsx
@@ -45,7 +45,7 @@ import { concatMap, filter, map } from 'rxjs/operators';
 import { EventTemplate } from './CreateRecording';
 
 export interface CustomRecordingFormProps {
-  onSubmit: (command: string, args: string[]) => void;
+  onSubmit: (recordingName: string, events: string, duration?: number) => void;
 }
 
 export const RecordingNamePattern = /^[\w_]+$/;
@@ -102,8 +102,6 @@ export const CustomRecordingForm = (props) => {
   };
 
   const handleSubmit = () => {
-    const eventString = getEventString();
-
     const notificationMessages: string[] = [];
     if (nameValid !== ValidatedOptions.success) {
       notificationMessages.push(`Recording name ${recordingName} is invalid`);
@@ -116,15 +114,7 @@ export const CustomRecordingForm = (props) => {
       notifications.warning('Invalid form data', message);
       return;
     }
-
-    const command = continuous ? 'start' : 'dump';
-    const args = [recordingName];
-    if (!continuous) {
-      const eventDuration = continuous ? 0 : duration * durationUnit;
-      args.push(String(eventDuration));
-    }
-    args.push(eventString);
-    props.onSubmit(command, args);
+    props.onSubmit(recordingName, getEventString(), continuous ? undefined : duration * durationUnit);
   };
 
   React.useEffect(() => {

--- a/src/app/CreateRecording/CustomRecordingForm.tsx
+++ b/src/app/CreateRecording/CustomRecordingForm.tsx
@@ -118,7 +118,7 @@ export const CustomRecordingForm = (props) => {
   };
 
   React.useEffect(() => {
-    context.commandChannel.target().pipe(concatMap(target => context.api.doGet<EventTemplate[]>(`targets/${encodeURIComponent(target)}/templates`))).subscribe(setTemplates);
+    context.target.target().pipe(concatMap(target => context.api.doGet<EventTemplate[]>(`targets/${encodeURIComponent(target)}/templates`))).subscribe(setTemplates);
   }, []);
 
   React.useEffect(() => {

--- a/src/app/CreateRecording/CustomRecordingForm.tsx
+++ b/src/app/CreateRecording/CustomRecordingForm.tsx
@@ -41,7 +41,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { ActionGroup, Button, Checkbox, Form, FormGroup, FormSelect, FormSelectOption, FormSelectOptionGroup, Split, SplitItem, Text, TextArea, TextInput, TextVariants, Tooltip, TooltipPosition, ValidatedOptions } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { useHistory } from 'react-router-dom';
-import { filter, map } from 'rxjs/operators';
+import { concatMap, filter, map } from 'rxjs/operators';
 import { EventTemplate } from './CreateRecording';
 
 export interface CustomRecordingFormProps {
@@ -128,21 +128,8 @@ export const CustomRecordingForm = (props) => {
   };
 
   React.useEffect(() => {
-    const sub = context.commandChannel.onResponse('list-event-templates')
-      .pipe(
-        filter(m => m.status === 0),
-        map(m => m.payload),
-      )
-      .subscribe(setTemplates);
-    return () => sub.unsubscribe();
-  }, [context.commandChannel]);
-
-  React.useEffect(() => {
-    const sub = context.commandChannel.target().subscribe(target =>
-      context.commandChannel.sendMessage('list-event-templates')
-    );
-    return () => sub.unsubscribe();
-  }, [context.commandChannel]);
+    context.commandChannel.target().pipe(concatMap(target => context.api.doGet<EventTemplate[]>(`targets/${encodeURIComponent(target)}/templates`))).subscribe(setTemplates);
+  }, []);
 
   React.useEffect(() => {
     if (TemplatePattern.test(eventSpecifiers)) {

--- a/src/app/CreateRecording/SnapshotRecordingForm.tsx
+++ b/src/app/CreateRecording/SnapshotRecordingForm.tsx
@@ -40,15 +40,11 @@ import { ActionGroup, Button, Form, Text, TextVariants } from '@patternfly/react
 import { useHistory } from 'react-router-dom';
 
 export interface SnapshotRecordingFormProps {
-  onSubmit: (command: string, args: string[]) => void;
+  onSubmit: Function;
 }
 
 export const SnapshotRecordingForm = (props) => {
   const history = useHistory();
-
-  const handleSubmit = () => {
-    props.onSubmit('snapshot', []);
-  };
 
   return (<>
     <Form>
@@ -60,7 +56,7 @@ export const SnapshotRecordingForm = (props) => {
         is only ever in the STOPPED state from the moment it is created.
       </Text>
       <ActionGroup>
-        <Button variant="primary" onClick={handleSubmit}>Create</Button>
+        <Button variant="primary" onClick={props.onSubmit}>Create</Button>
         <Button variant="secondary" onClick={history.goBack}>Cancel</Button>
       </ActionGroup>
     </Form>

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -84,7 +84,7 @@ export const EventTemplates = () => {
   }, [filterText, templates, sortBy]);
 
   const refreshTemplates = () => {
-    context.commandChannel.target().pipe(concatMap(target => context.api.doGet<EventTemplate[]>(`targets/${encodeURIComponent(target)}/templates`))).subscribe(setTemplates);
+    context.target.target().pipe(concatMap(target => context.api.doGet<EventTemplate[]>(`targets/${encodeURIComponent(target)}/templates`))).subscribe(setTemplates);
   };
 
   React.useEffect(() => {
@@ -116,7 +116,7 @@ export const EventTemplates = () => {
       actions = actions.concat([
           {
             title: 'Download',
-            onClick: (event, rowId) => context.commandChannel.target().pipe(first()).subscribe(target => context.api.downloadTemplate(target, filteredTemplates[rowId])),          
+            onClick: (event, rowId) => context.target.target().pipe(first()).subscribe(target => context.api.downloadTemplate(target, filteredTemplates[rowId])),
           }
       ]);
     };

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -116,7 +116,7 @@ export const EventTemplates = () => {
       actions = actions.concat([
           {
             title: 'Download',
-            onClick: (event, rowId) => context.target.target().pipe(first()).subscribe(target => context.api.downloadTemplate(target, filteredTemplates[rowId])),
+            onClick: (event, rowId) => context.api.downloadTemplate(filteredTemplates[rowId]),
           }
       ]);
     };

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -43,7 +43,7 @@ import { ActionGroup, Button, FileUpload, Form, FormGroup, Modal, ModalVariant, 
 import { PlusIcon } from '@patternfly/react-icons';
 import { Table, TableBody, TableHeader, TableVariant, IAction, IRowData, IExtraData, ISortBy, SortByDirection, sortable } from '@patternfly/react-table';
 import { useHistory } from 'react-router-dom';
-import { concatMap, filter, first, map } from 'rxjs/operators';
+import { concatMap, first } from 'rxjs/operators';
 
 export const EventTemplates = () => {
   const context = React.useContext(ServiceContext);
@@ -131,7 +131,7 @@ export const EventTemplates = () => {
             onClick: (event, rowId) => context.api.downloadTemplate(filteredTemplates[rowId]),
           }
       ]);
-    };
+    }
     if (template.type === 'CUSTOM') {
       actions = actions.concat([
           {

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -38,6 +38,7 @@
 import * as React from 'react';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { EventTemplate } from '@app/Shared/Services/Api.service';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { ActionGroup, Button, FileUpload, Form, FormGroup, Modal, ModalVariant, Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem, TextInput } from '@patternfly/react-core';
 import { PlusIcon } from '@patternfly/react-icons';
 import { Table, TableBody, TableHeader, TableVariant, IAction, IRowData, IExtraData, ISortBy, SortByDirection, sortable } from '@patternfly/react-table';
@@ -57,6 +58,7 @@ export const EventTemplates = () => {
   const [uploading, setUploading] = React.useState(false);
   const [fileRejected, setFileRejected] = React.useState(false);
   const [sortBy, setSortBy] = React.useState({} as ISortBy);
+  const addSubscription = useSubscriptions();
 
   const tableColumns = [
     { title: 'Name', transforms: [ sortable ] },
@@ -84,7 +86,9 @@ export const EventTemplates = () => {
   }, [filterText, templates, sortBy]);
 
   const refreshTemplates = () => {
-    context.target.target().pipe(concatMap(target => context.api.doGet<EventTemplate[]>(`targets/${encodeURIComponent(target)}/templates`))).subscribe(setTemplates);
+    addSubscription(
+      context.target.target().pipe(concatMap(target => context.api.doGet<EventTemplate[]>(`targets/${encodeURIComponent(target)}/templates`))).subscribe(setTemplates)
+    );
   };
 
   React.useEffect(() => {
@@ -97,7 +101,9 @@ export const EventTemplates = () => {
   );
 
   const handleDelete = (rowData) => {
-    context.api.deleteCustomEventTemplate(rowData[0]).subscribe(refreshTemplates);
+    addSubscription(
+      context.api.deleteCustomEventTemplate(rowData[0]).subscribe(refreshTemplates)
+    );
   };
 
   const actionResolver = (rowData: IRowData, extraData: IExtraData) => {
@@ -157,15 +163,17 @@ export const EventTemplates = () => {
       return;
     }
     setUploading(true);
-    context.api.addCustomEventTemplate(uploadFile).subscribe(success => {
-      setUploading(false);
-      if (success) {
-        setUploadFile(undefined);
-        setUploadFilename('');
-        refreshTemplates();
-        setModalOpen(false);
-      }
-    });
+    addSubscription(
+      context.api.addCustomEventTemplate(uploadFile).subscribe(success => {
+        setUploading(false);
+        if (success) {
+          setUploadFile(undefined);
+          setUploadFilename('');
+          refreshTemplates();
+          setModalOpen(false);
+        }
+      })
+    );
   };
 
   const handleUploadCancel = () => {

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -87,7 +87,11 @@ export const EventTemplates = () => {
 
   const refreshTemplates = () => {
     addSubscription(
-      context.target.target().pipe(concatMap(target => context.api.doGet<EventTemplate[]>(`targets/${encodeURIComponent(target)}/templates`))).subscribe(setTemplates)
+      context.target.target()
+      .pipe(
+        concatMap(target => context.api.doGet<EventTemplate[]>(`targets/${encodeURIComponent(target)}/templates`)),
+        first(),
+      ).subscribe(setTemplates)
     );
   };
 
@@ -102,7 +106,9 @@ export const EventTemplates = () => {
 
   const handleDelete = (rowData) => {
     addSubscription(
-      context.api.deleteCustomEventTemplate(rowData[0]).subscribe(refreshTemplates)
+      context.api.deleteCustomEventTemplate(rowData[0])
+      .pipe(first())
+      .subscribe(refreshTemplates)
     );
   };
 
@@ -164,7 +170,9 @@ export const EventTemplates = () => {
     }
     setUploading(true);
     addSubscription(
-      context.api.addCustomEventTemplate(uploadFile).subscribe(success => {
+      context.api.addCustomEventTemplate(uploadFile)
+      .pipe(first())
+      .subscribe(success => {
         setUploading(false);
         if (success) {
           setUploadFile(undefined);

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -84,7 +84,8 @@ export const EventTypes = () => {
   ];
 
   React.useEffect(() => {
-    context.target.target().pipe(concatMap(target => context.api.doGet<EventType[]>(`targets/${encodeURIComponent(target)}/events`))).subscribe(setTypes)
+    const sub = context.target.target().pipe(concatMap(target => context.api.doGet<EventType[]>(`targets/${encodeURIComponent(target)}/events`))).subscribe(setTypes)
+    return () => sub.unsubscribe();
   }, [context.commandChannel]);
 
   const getCategoryString = (eventType: EventType): string => {

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -39,7 +39,7 @@ import * as React from 'react';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { Toolbar, ToolbarContent, ToolbarItem, ToolbarItemVariant, Pagination, TextInput } from '@patternfly/react-core';
 import { expandable, Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-table';
-import { filter, map } from 'rxjs/operators';
+import { concatMap, filter, map } from 'rxjs/operators';
 
 export interface EventType {
   name: string;
@@ -84,17 +84,7 @@ export const EventTypes = () => {
   ];
 
   React.useEffect(() => {
-    const sub = context.commandChannel.onResponse('list-event-types')
-      .pipe(
-        filter(m => m.status === 0),
-        map(m => m.payload),
-      )
-      .subscribe(types => setTypes(types));
-    return () => sub.unsubscribe();
-  }, [context.commandChannel]);
-
-  React.useEffect(() => {
-    context.commandChannel.sendMessage('list-event-types');
+    context.commandChannel.target().pipe(concatMap(target => context.api.doGet<EventType[]>(`targets/${encodeURIComponent(target)}/events`))).subscribe(setTypes)
   }, [context.commandChannel]);
 
   const getCategoryString = (eventType: EventType): string => {

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -39,7 +39,7 @@ import * as React from 'react';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { Toolbar, ToolbarContent, ToolbarItem, ToolbarItemVariant, Pagination, TextInput } from '@patternfly/react-core';
 import { expandable, Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-table';
-import { concatMap, filter, map } from 'rxjs/operators';
+import { concatMap } from 'rxjs/operators';
 
 export interface EventType {
   name: string;

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2020 Red Hat, Inc.
- * 
+ *
  * The Universal Permissive License (UPL), Version 1.0
- * 
+ *
  * Subject to the condition set forth below, permission is hereby granted to any
  * person obtaining a copy of this software, associated documentation and/or data
  * (collectively the "Software"), free of charge and under any and all copyright
@@ -10,23 +10,23 @@
  * licensable by each licensor hereunder covering either (i) the unmodified
  * Software as contributed to or provided by such licensor, or (ii) the Larger
  * Works (as defined below), to deal in both
- * 
+ *
  * (a) the Software, and
  * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
  * one is included with the Software (each a "Larger Work" to which the Software
  * is contributed by such licensors),
- * 
+ *
  * without restriction, including without limitation the rights to copy, create
  * derivative works of, display, perform, and distribute the Software and make,
  * use, sell, offer for sale, import, export, have made, and have sold the
  * Software and the Larger Work(s), and to sublicense the foregoing rights on
  * either these or other terms.
- * 
+ *
  * This license is subject to the following condition:
  * The above copyright notice and either this complete permission notice or at
  * a minimum a reference to the UPL must be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -84,7 +84,7 @@ export const EventTypes = () => {
   ];
 
   React.useEffect(() => {
-    context.commandChannel.target().pipe(concatMap(target => context.api.doGet<EventType[]>(`targets/${encodeURIComponent(target)}/events`))).subscribe(setTypes)
+    context.target.target().pipe(concatMap(target => context.api.doGet<EventType[]>(`targets/${encodeURIComponent(target)}/events`))).subscribe(setTypes)
   }, [context.commandChannel]);
 
   const getCategoryString = (eventType: EventType): string => {

--- a/src/app/Login/Login.tsx
+++ b/src/app/Login/Login.tsx
@@ -39,6 +39,7 @@ import * as React from 'react';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { Card, CardBody, CardFooter, CardHeader, PageSection, Title } from '@patternfly/react-core';
+import { first } from 'rxjs/operators';
 import { BasicAuthDescriptionText, BasicAuthForm } from './BasicAuthForm';
 import { BearerAuthDescriptionText, BearerAuthForm } from './BearerAuthForm';
 
@@ -56,7 +57,9 @@ export const Login = (props) => {
       tok = window.btoa(token);
     } // else this is Bearer auth and the token is sent as-is
     addSubscription(
-      context.api.checkAuth(tok, authMethod).subscribe(v => {
+      context.api.checkAuth(tok, authMethod)
+      .pipe(first())
+      .subscribe(v => {
         if (v) {
           onLoginSuccess();
         }

--- a/src/app/Login/Login.tsx
+++ b/src/app/Login/Login.tsx
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2020 Red Hat, Inc.
- * 
+ *
  * The Universal Permissive License (UPL), Version 1.0
- * 
+ *
  * Subject to the condition set forth below, permission is hereby granted to any
  * person obtaining a copy of this software, associated documentation and/or data
  * (collectively the "Software"), free of charge and under any and all copyright
@@ -10,23 +10,23 @@
  * licensable by each licensor hereunder covering either (i) the unmodified
  * Software as contributed to or provided by such licensor, or (ii) the Larger
  * Works (as defined below), to deal in both
- * 
+ *
  * (a) the Software, and
  * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
  * one is included with the Software (each a "Larger Work" to which the Software
  * is contributed by such licensors),
- * 
+ *
  * without restriction, including without limitation the rights to copy, create
  * derivative works of, display, perform, and distribute the Software and make,
  * use, sell, offer for sale, import, export, have made, and have sold the
  * Software and the Larger Work(s), and to sublicense the foregoing rights on
  * either these or other terms.
- * 
+ *
  * This license is subject to the following condition:
  * The above copyright notice and either this complete permission notice or at
  * a minimum a reference to the UPL must be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -37,6 +37,7 @@
  */
 import * as React from 'react';
 import { ServiceContext } from '@app/Shared/Services/Services';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { Card, CardBody, CardFooter, CardHeader, PageSection, Title } from '@patternfly/react-core';
 import { BasicAuthDescriptionText, BasicAuthForm } from './BasicAuthForm';
 import { BearerAuthDescriptionText, BearerAuthForm } from './BearerAuthForm';
@@ -46,6 +47,7 @@ export const Login = (props) => {
 
   const [token, setToken] = React.useState('');
   const [authMethod, setAuthMethod] = React.useState('Basic');
+  const addSubscription = useSubscriptions();
   const onLoginSuccess = props.onLoginSuccess;
 
   const checkAuth = React.useCallback(() => {
@@ -53,11 +55,13 @@ export const Login = (props) => {
     if (authMethod === 'Basic') {
       tok = window.btoa(token);
     } // else this is Bearer auth and the token is sent as-is
-    context.api.checkAuth(tok, authMethod).subscribe(v => {
-      if (v) {
-        onLoginSuccess();
-      }
-    })
+    addSubscription(
+      context.api.checkAuth(tok, authMethod).subscribe(v => {
+        if (v) {
+          onLoginSuccess();
+        }
+      })
+    );
   }, [context.api, token, authMethod, onLoginSuccess]);
 
   const handleSubmit = (evt, token, authMethod) => {

--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -95,7 +95,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
     addSubscription(
       context.target.target()
       .pipe(
-        concatMap(target => context.api.doGet<Recording[]>(`/targets/${encodeURIComponent(target)}/recordings`)),
+        concatMap(target => context.api.doGet<Recording[]>(`targets/${encodeURIComponent(target)}/recordings`)),
         first(),
       ).subscribe(newRecordings => {
         if (!_.isEqual(newRecordings, recordings)) {

--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -44,8 +44,8 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { Button, DataListAction, DataListCell, DataListCheck, DataListContent, DataListItem, DataListItemCells, DataListItemRow, DataListToggle, Dropdown, DropdownItem, DropdownPosition, KebabToggle, Text, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
 import { useHistory, useRouteMatch } from 'react-router-dom';
-import { forkJoin, from, Observable, Subscription } from 'rxjs';
-import { concatMap, filter, first, map } from 'rxjs/operators';
+import { forkJoin, Observable } from 'rxjs';
+import { concatMap, first } from 'rxjs/operators';
 import { RecordingsDataTable } from './RecordingsDataTable';
 import { ReportFrame } from './ReportFrame';
 
@@ -120,7 +120,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
         if (props.onArchive && arr.some(v => !!v)) {
           props.onArchive();
         }
-      }, console.error)
+      }, window.console.error)
     );
   };
 
@@ -137,12 +137,12 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
       }
     });
     addSubscription(
-      forkJoin(tasks).subscribe(refreshRecordingList, console.error)
+      forkJoin(tasks).subscribe(refreshRecordingList, window.console.error)
     );
   };
 
   const handleDeleteRecordings = () => {
-    const tasks: Observable<any>[] = [];
+    const tasks: Observable<{}>[] = [];
     recordings.forEach((r: Recording, idx) => {
       if (checkedIndices.includes(idx)) {
         handleRowCheck(false, idx);
@@ -152,14 +152,14 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
       }
     });
     addSubscription(
-      forkJoin(tasks).subscribe(refreshRecordingList, console.error)
+      forkJoin(tasks).subscribe(refreshRecordingList, window.console.error)
     );
   };
 
   React.useEffect(() => {
     refreshRecordingList();
-    const id = setInterval(() => refreshRecordingList(), 30_000);
-    return () => clearInterval(id);
+    const id = window.setInterval(() => refreshRecordingList(), 30_000);
+    return () => window.clearInterval(id);
   }, [context.commandChannel]);
 
   const RecordingRow = (props) => {

--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2020 Red Hat, Inc.
- * 
+ *
  * The Universal Permissive License (UPL), Version 1.0
- * 
+ *
  * Subject to the condition set forth below, permission is hereby granted to any
  * person obtaining a copy of this software, associated documentation and/or data
  * (collectively the "Software"), free of charge and under any and all copyright
@@ -10,23 +10,23 @@
  * licensable by each licensor hereunder covering either (i) the unmodified
  * Software as contributed to or provided by such licensor, or (ii) the Larger
  * Works (as defined below), to deal in both
- * 
+ *
  * (a) the Software, and
  * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
  * one is included with the Software (each a "Larger Work" to which the Software
  * is contributed by such licensors),
- * 
+ *
  * without restriction, including without limitation the rights to copy, create
  * derivative works of, display, perform, and distribute the Software and make,
  * use, sell, offer for sale, import, export, have made, and have sold the
  * Software and the Larger Work(s), and to sublicense the foregoing rights on
  * either these or other terms.
- * 
+ *
  * This license is subject to the following condition:
  * The above copyright notice and either this complete permission notice or at
  * a minimum a reference to the UPL must be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -42,19 +42,21 @@ import { Recording, RecordingState } from '@app/Shared/Services/Api.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { Button, DataListAction, DataListCell, DataListCheck, DataListContent, DataListItem, DataListItemCells, DataListItemRow, DataListToggle, Dropdown, DropdownItem, DropdownPosition, KebabToggle, Text, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
 import { useHistory, useRouteMatch } from 'react-router-dom';
-import { filter, first, map } from 'rxjs/operators';
+import { forkJoin, from, Observable } from 'rxjs';
+import { concatMap, filter, first, map } from 'rxjs/operators';
 import { RecordingsDataTable } from './RecordingsDataTable';
 import { ReportFrame } from './ReportFrame';
 
 export interface ActiveRecordingsListProps {
   archiveEnabled: boolean;
+  onArchive?: Function;
 }
 
 export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListProps> = (props) => {
   const context = React.useContext(ServiceContext);
   const routerHistory = useHistory();
 
-  const [recordings, setRecordings] = React.useState([]);
+  const [recordings, setRecordings] = React.useState([] as Recording[]);
   const [headerChecked, setHeaderChecked] = React.useState(false);
   const [checkedIndices, setCheckedIndices] = React.useState([] as number[]);
   const [expandedRows, setExpandedRows] = React.useState([] as string[]);
@@ -85,35 +87,90 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
     routerHistory.push(`${url}/create`);
   };
 
+  const refreshRecordingList = () => {
+    context.commandChannel.target().pipe(
+      concatMap(target => context.api.doGet<Recording[]>(`/targets/${encodeURIComponent(target)}/recordings`))
+    ).subscribe(setRecordings);
+  };
+
   const handleArchiveRecordings = () => {
     recordings.forEach((r: Recording, idx) => {
       if (checkedIndices.includes(idx)) {
         handleRowCheck(false, idx);
-        context.commandChannel.sendMessage('save', [ r.name ]);
+        context.commandChannel.target()
+          .pipe(
+            concatMap(
+              target => context.api.sendRequest(
+                `targets/${encodeURIComponent(target)}/recordings/${encodeURIComponent(r.name)}`,
+                {
+                  method: 'PATCH',
+                  body: 'SAVE',
+                }
+              )),
+            map(resp => resp.text()),
+            concatMap(from),
+            first(),
+          )
+          .subscribe(() => {
+            if (props.onArchive) {
+              props.onArchive();
+            }
+          });
       }
     });
   };
 
   const handleStopRecordings = () => {
+    const tasks: Observable<any>[] = [];
     recordings.forEach((r: Recording, idx) => {
       if (checkedIndices.includes(idx)) {
         handleRowCheck(false, idx);
         if (r.state === RecordingState.RUNNING || r.state === RecordingState.STARTING) {
-          context.commandChannel.sendMessage('stop', [ r.name ]);
+          tasks.push(
+            context.commandChannel.target()
+              .pipe(
+                concatMap(
+                  target => context.api.sendRequest(
+                    `targets/${encodeURIComponent(target)}/recordings/${encodeURIComponent(r.name)}`,
+                    {
+                      method: 'PATCH',
+                      body: 'STOP',
+                    }
+                  )),
+                map(resp => resp.text()),
+                concatMap(from),
+                first(),
+              )
+          );
         }
       }
     });
-    context.commandChannel.sendMessage('list');
+    forkJoin(tasks).subscribe(refreshRecordingList);
   };
 
   const handleDeleteRecordings = () => {
+    const tasks: Observable<any>[] = [];
     recordings.forEach((r: Recording, idx) => {
       if (checkedIndices.includes(idx)) {
         handleRowCheck(false, idx);
-        context.commandChannel.sendMessage('delete', [ r.name ]);
+        tasks.push(
+          context.commandChannel.target()
+            .pipe(
+              concatMap(
+                target => context.api.sendRequest(
+                  `targets/${encodeURIComponent(target)}/recordings/${encodeURIComponent(r.name)}`,
+                  {
+                    method: 'DELETE',
+                  }
+                )),
+              map(resp => resp.text()),
+              concatMap(from),
+              first(),
+            )
+        );
       }
     });
-    context.commandChannel.sendMessage('list');
+    forkJoin(tasks).subscribe(refreshRecordingList);
   };
 
   React.useEffect(() => {
@@ -131,8 +188,8 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
   }, [context.commandChannel, recordings]);
 
   React.useEffect(() => {
-    context.commandChannel.sendMessage('list');
-    const id = setInterval(() => context.commandChannel.sendMessage('list'), 30_000);
+    refreshRecordingList();
+    const id = setInterval(() => refreshRecordingList(), 30_000);
     return () => clearInterval(id);
   }, [context.commandChannel]);
 
@@ -275,7 +332,6 @@ export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = 
   const notifications = React.useContext(NotificationsContext);
   const [open, setOpen] = React.useState(false);
   const [grafanaEnabled, setGrafanaEnabled] = React.useState(false);
-  const [uploadIds, setUploadIds] = React.useState([] as string[]);
 
   React.useEffect(() => {
     const sub = context.commandChannel.grafanaDatasourceUrl()
@@ -284,31 +340,28 @@ export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = 
     return () => sub.unsubscribe();
   }, [context.commandChannel]);
 
-  React.useEffect(() => {
-    const sub = context.commandChannel.onResponse('upload-recording')
-      .pipe(
-        filter(m => !!m.id && uploadIds.includes(m.id)),
-        first()
-      )
-      .subscribe(resp => {
-        const id = resp.id || '';
-        setUploadIds(ids => [...ids.slice(0, ids.indexOf(id)), ...ids.slice(ids.indexOf(id) + 1, ids.length)]);
-        if (resp.status === 0) {
-          notifications.success('Upload Success', `Recording "${props.recording.name}" uploaded`);
-          context.commandChannel.grafanaDashboardUrl().pipe(first()).subscribe(url => window.open(url, '_blank'));
-        } else {
-          notifications.danger('Upload Failed', `Recording "${props.recording.name}" could not be uploaded`);
-        }
-      });
-    return () => sub.unsubscribe();
-  }, [context.commandChannel, props.recording.name, notifications, uploadIds]);
-
   const grafanaUpload = () => {
     context.commandChannel.grafanaDatasourceUrl().pipe(first()).subscribe(url => {
       notifications.info('Upload Started', `Recording "${props.recording.name}" uploading...`);
-      const id = context.commandChannel.createMessageId();
-      setUploadIds(ids => [...ids, id]);
-      context.commandChannel.sendMessage('upload-recording', [ props.recording.name ], id);
+      context.commandChannel.target()
+        .pipe(
+          concatMap(
+            target => context.api.sendRequest(
+              `targets/${encodeURIComponent(target)}/recordings/${encodeURIComponent(props.recording.name)}/upload`,
+              {
+                method: 'POST',
+              }
+            )),
+          first(),
+        )
+        .subscribe(resp => {
+          if (resp.status === 0) {
+            notifications.success('Upload Success', `Recording "${props.recording.name}" uploaded`);
+            context.commandChannel.grafanaDashboardUrl().pipe(first()).subscribe(url => window.open(url, '_blank'));
+          } else {
+            notifications.danger('Upload Failed', `Recording "${props.recording.name}" could not be uploaded`);
+          }
+        });
     });
   };
 

--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -135,7 +135,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
       if (checkedIndices.includes(idx)) {
         handleRowCheck(false, idx);
         tasks.push(
-          context.api.deleteRecording(r.name)
+          context.api.deleteRecording(r.name).pipe(first())
         );
       }
     });

--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -88,7 +88,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
   };
 
   const refreshRecordingList = () => {
-    context.commandChannel.target().pipe(
+    context.target.target().pipe(
       concatMap(target => context.api.doGet<Recording[]>(`/targets/${encodeURIComponent(target)}/recordings`))
     ).subscribe(newRecordings => {
       if (!_.isEqual(newRecordings, recordings)) {
@@ -103,7 +103,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
       if (checkedIndices.includes(idx)) {
         handleRowCheck(false, idx);
         tasks.push(
-          context.commandChannel.target()
+          context.target.target()
             .pipe(
               concatMap(target => context.api.archiveRecording(target, r.name)),
               first()
@@ -125,7 +125,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
         handleRowCheck(false, idx);
         if (r.state === RecordingState.RUNNING || r.state === RecordingState.STARTING) {
           tasks.push(
-            context.commandChannel.target()
+            context.target.target()
               .pipe(
                 concatMap(target => context.api.stopRecording(target, r.name)),
                 first()
@@ -143,7 +143,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
       if (checkedIndices.includes(idx)) {
         handleRowCheck(false, idx);
         tasks.push(
-          context.commandChannel.target()
+          context.target.target()
             .pipe(
               concatMap(target => context.api.deleteRecording(target, r.name)),
               first(),
@@ -309,7 +309,7 @@ export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = 
 
   const grafanaUpload = () => {
       notifications.info('Upload Started', `Recording "${props.recording.name}" uploading...`);
-      context.commandChannel.target()
+      context.target.target()
         .pipe(
           concatMap(
             target => context.api.uploadRecordingToGrafana(target, props.recording.name)),

--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -93,8 +93,10 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
 
   const refreshRecordingList = () => {
     addSubscription(
-      context.target.target().pipe(
-        concatMap(target => context.api.doGet<Recording[]>(`/targets/${encodeURIComponent(target)}/recordings`))
+      context.target.target()
+      .pipe(
+        concatMap(target => context.api.doGet<Recording[]>(`/targets/${encodeURIComponent(target)}/recordings`)),
+        first(),
       ).subscribe(newRecordings => {
         if (!_.isEqual(newRecordings, recordings)) {
           setRecordings(newRecordings);
@@ -313,12 +315,13 @@ export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = 
     notifications.info('Upload Started', `Recording "${props.recording.name}" uploading...`);
     addSubscription(
       context.api.uploadRecordingToGrafana(props.recording.name)
-        .subscribe(success => {
-          if (success) {
-            notifications.success('Upload Success', `Recording "${props.recording.name}" uploaded`);
-            context.commandChannel.grafanaDashboardUrl().pipe(first()).subscribe(url => window.open(url, '_blank'));
-          }
-        })
+      .pipe(first())
+      .subscribe(success => {
+        if (success) {
+          notifications.success('Upload Success', `Recording "${props.recording.name}" uploaded`);
+          context.commandChannel.grafanaDashboardUrl().pipe(first()).subscribe(url => window.open(url, '_blank'));
+        }
+      })
     );
   };
 

--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -103,11 +103,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
       if (checkedIndices.includes(idx)) {
         handleRowCheck(false, idx);
         tasks.push(
-          context.target.target()
-            .pipe(
-              concatMap(target => context.api.archiveRecording(target, r.name)),
-              first()
-            )
+          context.api.archiveRecording(r.name).pipe(first())
         );
       }
     });
@@ -125,11 +121,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
         handleRowCheck(false, idx);
         if (r.state === RecordingState.RUNNING || r.state === RecordingState.STARTING) {
           tasks.push(
-            context.target.target()
-              .pipe(
-                concatMap(target => context.api.stopRecording(target, r.name)),
-                first()
-              )
+            context.api.stopRecording(r.name).pipe(first())
           );
         }
       }
@@ -143,11 +135,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
       if (checkedIndices.includes(idx)) {
         handleRowCheck(false, idx);
         tasks.push(
-          context.target.target()
-            .pipe(
-              concatMap(target => context.api.deleteRecording(target, r.name)),
-              first(),
-            )
+          context.api.deleteRecording(r.name)
         );
       }
     });
@@ -309,11 +297,7 @@ export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = 
 
   const grafanaUpload = () => {
       notifications.info('Upload Started', `Recording "${props.recording.name}" uploading...`);
-      context.target.target()
-        .pipe(
-          concatMap(
-            target => context.api.uploadRecordingToGrafana(target, props.recording.name)),
-        )
+      context.api.uploadRecordingToGrafana(props.recording.name)
         .subscribe(success => {
           if (success) {
             notifications.success('Upload Success', `Recording "${props.recording.name}" uploaded`);

--- a/src/app/RecordingList/ArchivedRecordingsList.tsx
+++ b/src/app/RecordingList/ArchivedRecordingsList.tsx
@@ -81,7 +81,9 @@ export const ArchivedRecordingsList: React.FunctionComponent<ArchivedRecordingsL
 
   const refreshRecordingList = () => {
     addSubscription(
-      context.api.doGet<Recording[]>(`recordings`).subscribe(newRecordings => {
+      context.api.doGet<Recording[]>(`recordings`)
+      .pipe(first())
+      .subscribe(newRecordings => {
         if (!_.isEqual(newRecordings, recordings)) {
           setRecordings(newRecordings);
         }
@@ -95,8 +97,7 @@ export const ArchivedRecordingsList: React.FunctionComponent<ArchivedRecordingsL
       if (checkedIndices.includes(idx)) {
         handleRowCheck(false, idx);
         tasks.push(
-          context.api.deleteArchivedRecording(r.name)
-          .pipe(first())
+          context.api.deleteArchivedRecording(r.name).pipe(first())
         );
       }
     });

--- a/src/app/RecordingList/ArchivedRecordingsList.tsx
+++ b/src/app/RecordingList/ArchivedRecordingsList.tsx
@@ -91,9 +91,8 @@ export const ArchivedRecordingsList: React.FunctionComponent<ArchivedRecordingsL
       if (checkedIndices.includes(idx)) {
         handleRowCheck(false, idx);
         tasks.push(
-          context.api.sendRequest(`recordings/${encodeURIComponent(r.name)}`, {
-            method: 'DELETE'
-          }).pipe(first())
+          context.api.deleteArchivedRecording(r.name)
+          .pipe(first())
         );
       }
     });

--- a/src/app/RecordingList/ArchivedRecordingsList.tsx
+++ b/src/app/RecordingList/ArchivedRecordingsList.tsx
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2020 Red Hat, Inc.
- * 
+ *
  * The Universal Permissive License (UPL), Version 1.0
- * 
+ *
  * Subject to the condition set forth below, permission is hereby granted to any
  * person obtaining a copy of this software, associated documentation and/or data
  * (collectively the "Software"), free of charge and under any and all copyright
@@ -10,23 +10,23 @@
  * licensable by each licensor hereunder covering either (i) the unmodified
  * Software as contributed to or provided by such licensor, or (ii) the Larger
  * Works (as defined below), to deal in both
- * 
+ *
  * (a) the Software, and
  * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
  * one is included with the Software (each a "Larger Work" to which the Software
  * is contributed by such licensors),
- * 
+ *
  * without restriction, including without limitation the rights to copy, create
  * derivative works of, display, perform, and distribute the Software and make,
  * use, sell, offer for sale, import, export, have made, and have sold the
  * Software and the Larger Work(s), and to sublicense the foregoing rights on
  * either these or other terms.
- * 
+ *
  * This license is subject to the following condition:
  * The above copyright notice and either this complete permission notice or at
  * a minimum a reference to the UPL must be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -44,8 +44,13 @@ import { filter, map } from 'rxjs/operators';
 import { RecordingActions } from './ActiveRecordingsList';
 import { RecordingsDataTable } from './RecordingsDataTable';
 import { ReportFrame } from './ReportFrame';
+import { Subject } from 'rxjs';
 
-export const ArchivedRecordingsList = () => {
+interface ArchivedRecordingsListProps {
+  updater: Subject<void>;
+}
+
+export const ArchivedRecordingsList: React.FunctionComponent<ArchivedRecordingsListProps> = (props) => {
   const context = React.useContext(ServiceContext);
 
   const [recordings, setRecordings] = React.useState([]);
@@ -88,9 +93,11 @@ export const ArchivedRecordingsList = () => {
   };
 
   React.useEffect(() => {
-    const sub = context.commandChannel.onResponse('save').subscribe(() => context.commandChannel.sendControlMessage('list-saved'));
+    const sub = props.updater.subscribe(() => {
+      context.commandChannel.sendControlMessage('list-saved');
+    });
     return () => sub.unsubscribe();
-  }, [context.commandChannel]);
+  }, [props.updater])
 
   React.useEffect(() => {
     const sub = context.commandChannel.onResponse('list-saved')

--- a/src/app/RecordingList/ArchivedRecordingsList.tsx
+++ b/src/app/RecordingList/ArchivedRecordingsList.tsx
@@ -40,12 +40,12 @@ import * as _ from 'lodash';
 import { Recording } from '@app/Shared/Services/Api.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { Button, DataListCell, DataListCheck, DataListContent, DataListItem, DataListItemCells, DataListItemRow, DataListToggle, Spinner, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
+import { Button, DataListCell, DataListCheck, DataListContent, DataListItem, DataListItemCells, DataListItemRow, DataListToggle, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
 import { RecordingActions } from './ActiveRecordingsList';
 import { RecordingsDataTable } from './RecordingsDataTable';
 import { ReportFrame } from './ReportFrame';
-import { Observable, Subject, forkJoin, from } from 'rxjs';
-import { concatMap, filter, first, map } from 'rxjs/operators';
+import { Observable, Subject, forkJoin } from 'rxjs';
+import { first } from 'rxjs/operators';
 
 interface ArchivedRecordingsListProps {
   updater: Subject<void>;
@@ -58,7 +58,6 @@ export const ArchivedRecordingsList: React.FunctionComponent<ArchivedRecordingsL
   const [headerChecked, setHeaderChecked] = React.useState(false);
   const [checkedIndices, setCheckedIndices] = React.useState([] as number[]);
   const [expandedRows, setExpandedRows] = React.useState([] as string[]);
-  const [openAction, setOpenAction] = React.useState(-1);
   const addSubscription = useSubscriptions();
 
   const tableColumns: string[] = [
@@ -118,26 +117,19 @@ export const ArchivedRecordingsList: React.FunctionComponent<ArchivedRecordingsL
 
   React.useEffect(() => {
     refreshRecordingList();
-    const id = setInterval(refreshRecordingList, 30_000);
-    return () => clearInterval(id);
+    const id = window.setInterval(refreshRecordingList, 30_000);
+    return () => window.clearInterval(id);
   }, [context.commandChannel]);
 
   const RecordingRow = (props) => {
-    const [reportLoaded, setReportLoaded] = React.useState(false);
-
     const expandedRowId =`archived-table-row-${props.index}-exp`;
     const handleToggle = () => {
-      setReportLoaded(false);
       toggleExpanded(expandedRowId);
     };
 
     const isExpanded = React.useMemo(() => {
       return expandedRows.includes(expandedRowId);
     }, [expandedRows, expandedRowId]);
-
-    const onLoad = () => {
-      setReportLoaded(true);
-    };
 
     const handleCheck = (checked) => {
       handleRowCheck(checked, props.index);

--- a/src/app/RecordingList/ArchivedRecordingsList.tsx
+++ b/src/app/RecordingList/ArchivedRecordingsList.tsx
@@ -39,6 +39,7 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { Recording } from '@app/Shared/Services/Api.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { Button, DataListCell, DataListCheck, DataListContent, DataListItem, DataListItemCells, DataListItemRow, DataListToggle, Spinner, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
 import { RecordingActions } from './ActiveRecordingsList';
 import { RecordingsDataTable } from './RecordingsDataTable';
@@ -58,6 +59,7 @@ export const ArchivedRecordingsList: React.FunctionComponent<ArchivedRecordingsL
   const [checkedIndices, setCheckedIndices] = React.useState([] as number[]);
   const [expandedRows, setExpandedRows] = React.useState([] as string[]);
   const [openAction, setOpenAction] = React.useState(-1);
+  const addSubscription = useSubscriptions();
 
   const tableColumns: string[] = [
     'Name'
@@ -78,11 +80,13 @@ export const ArchivedRecordingsList: React.FunctionComponent<ArchivedRecordingsL
   };
 
   const refreshRecordingList = () => {
-    context.api.doGet<Recording[]>(`recordings`).subscribe(newRecordings => {
-      if (!_.isEqual(newRecordings, recordings)) {
-        setRecordings(newRecordings);
-      }
-    });
+    addSubscription(
+      context.api.doGet<Recording[]>(`recordings`).subscribe(newRecordings => {
+        if (!_.isEqual(newRecordings, recordings)) {
+          setRecordings(newRecordings);
+        }
+      })
+    );
   };
 
   const handleDeleteRecordings = () => {
@@ -96,7 +100,9 @@ export const ArchivedRecordingsList: React.FunctionComponent<ArchivedRecordingsL
         );
       }
     });
-    forkJoin(tasks).subscribe(refreshRecordingList);
+    addSubscription(
+      forkJoin(tasks).subscribe(refreshRecordingList)
+    );
   };
 
   const toggleExpanded = (id) => {

--- a/src/app/RecordingList/RecordingList.tsx
+++ b/src/app/RecordingList/RecordingList.tsx
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2020 Red Hat, Inc.
- * 
+ *
  * The Universal Permissive License (UPL), Version 1.0
- * 
+ *
  * Subject to the condition set forth below, permission is hereby granted to any
  * person obtaining a copy of this software, associated documentation and/or data
  * (collectively the "Software"), free of charge and under any and all copyright
@@ -10,23 +10,23 @@
  * licensable by each licensor hereunder covering either (i) the unmodified
  * Software as contributed to or provided by such licensor, or (ii) the Larger
  * Works (as defined below), to deal in both
- * 
+ *
  * (a) the Software, and
  * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
  * one is included with the Software (each a "Larger Work" to which the Software
  * is contributed by such licensors),
- * 
+ *
  * without restriction, including without limitation the rights to copy, create
  * derivative works of, display, perform, and distribute the Software and make,
  * use, sell, offer for sale, import, export, have made, and have sold the
  * Software and the Larger Work(s), and to sublicense the foregoing rights on
  * either these or other terms.
- * 
+ *
  * This license is subject to the following condition:
  * The above copyright notice and either this complete permission notice or at
  * a minimum a reference to the UPL must be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -41,25 +41,31 @@ import { TargetView } from '@app/TargetView/TargetView';
 import { Card, CardBody, CardHeader, Tab, Tabs, Text, TextVariants } from '@patternfly/react-core';
 import { ActiveRecordingsList } from './ActiveRecordingsList';
 import { ArchivedRecordingsList } from './ArchivedRecordingsList';
+import { Subject } from 'rxjs';
 
 export const RecordingList = () => {
   const context = React.useContext(ServiceContext);
   const [activeTab, setActiveTab] = React.useState(0);
   const [archiveEnabled, setArchiveEnabled] = React.useState(false);
+  const archiveUpdate = new Subject<void>();
 
   React.useEffect(() => {
     const sub = context.commandChannel.isArchiveEnabled().subscribe(setArchiveEnabled);
     return () => sub.unsubscribe();
   }, [context.commandChannel]);
 
+  React.useEffect(() => {
+    return () => archiveUpdate.complete();
+  }, []);
+
   const cardBody = React.useMemo(() => {
     return archiveEnabled ? (
       <Tabs activeKey={activeTab} onSelect={(evt, idx) => setActiveTab(Number(idx))}>
         <Tab eventKey={0} title="Active Recordings">
-          <ActiveRecordingsList archiveEnabled={true}/>
+          <ActiveRecordingsList archiveEnabled={true} onArchive={() => archiveUpdate.next()} />
         </Tab>
         <Tab eventKey={1} title="Archived Recordings">
-          <ArchivedRecordingsList />
+          <ArchivedRecordingsList updater={archiveUpdate} />
         </Tab>
       </Tabs>
     ) : (

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -37,7 +37,7 @@
  */
 import { from, Observable, ObservableInput, of, ReplaySubject } from 'rxjs';
 import { fromFetch } from 'rxjs/fetch';
-import { catchError, combineLatest, concatMap, first, flatMap, map, tap } from 'rxjs/operators';
+import { catchError, combineLatest, concatMap, first, map, tap } from 'rxjs/operators';
 import { TargetService } from './Target.service';
 import { Notifications } from '@app/Notifications/Notifications';
 
@@ -91,7 +91,7 @@ export class ApiService {
   }
 
   createRecording(
-    { recordingName, events, duration  } : { recordingName: string; events: string; duration?: number }
+    { recordingName, events, duration  }: { recordingName: string; events: string; duration?: number }
     ): Observable<boolean> {
       const form = new window.FormData();
       form.append('recordingName', recordingName);

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -65,7 +65,7 @@ export class ApiService {
       mode: 'cors',
       method: 'POST',
       body: null,
-      headers: this.getHeaders(token, method)
+      headers: this.getHeaders(token, method),
     })
     .pipe(
       map(response => {
@@ -227,61 +227,43 @@ export class ApiService {
   }
 
   deleteCustomEventTemplate(templateName: string): Observable<void> {
-    return this.getToken().pipe(
-      combineLatest(this.getAuthMethod()),
-      first()
-    ).pipe(
-      concatMap(auths =>
-        fromFetch(`${this.authority}/api/v1/templates/${templateName}`, {
-          credentials: 'include',
-          mode: 'cors',
-          method: 'DELETE',
-          body: null,
-          headers: this.getHeaders(auths[0], auths[1])
-        })
-        .pipe(
-          map(response => {
-            if (!response.ok) {
-              throw response.statusText;
-            }
-          }),
-          catchError((e: Error): ObservableInput<void> => {
-            window.console.error(JSON.stringify(e));
-            return of();
-          })
-        )
-    ));
+    return this.sendRequest(`templates/${templateName}`, {
+      method: 'DELETE',
+      body: null,
+    })
+    .pipe(
+      map(response => {
+        if (!response.ok) {
+          throw response.statusText;
+        }
+      }),
+      catchError((e: Error): ObservableInput<void> => {
+        window.console.error(JSON.stringify(e));
+        return of();
+      })
+    );
   }
 
   addCustomEventTemplate(file: File): Observable<boolean> {
     const body = new window.FormData();
     body.append('template', file);
-    return this.getToken().pipe(
-      combineLatest(this.getAuthMethod()),
-      first()
-    ).pipe(
-      concatMap(auths =>
-        fromFetch(`${this.authority}/api/v1/templates`, {
-          credentials: 'include',
-          mode: 'cors',
-          method: 'POST',
-          body,
-          headers: this.getHeaders(auths[0], auths[1])
-        })
-        .pipe(
-          map(response => {
-            if (!response.ok) {
-              throw response.statusText;
-            }
-            return true;
-          }),
-          catchError((e: Error): ObservableInput<boolean> => {
-            window.console.error(JSON.stringify(e));
-            this.notifications.danger('Template Upload Failed', JSON.stringify(e));
-            return of(false);
-          })
-        )
-    ));
+    return this.sendRequest(`templates`, {
+      method: 'POST',
+      body,
+    })
+    .pipe(
+      map(response => {
+        if (!response.ok) {
+          throw response.statusText;
+        }
+        return true;
+      }),
+      catchError((e: Error): ObservableInput<boolean> => {
+        window.console.error(JSON.stringify(e));
+        this.notifications.danger('Template Upload Failed', JSON.stringify(e));
+        return of(false);
+      })
+    );
   }
 
   doGet<T>(path: string): Observable<T> {

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -105,13 +105,13 @@ export class ApiService {
           body: form,
         }).pipe(
           tap(resp => {
-            if (isHttpOK(resp)) {
+            if (resp.ok) {
               this.notifications.success('Recording created');
             } else {
               this.notifications.danger(`Request failed (Status ${resp.status})`, resp.statusText)
             }
           }),
-          map(isHttpOK),
+          map(resp => resp.ok),
           first(),
         )));
   }
@@ -122,13 +122,13 @@ export class ApiService {
         method: 'POST',
       }).pipe(
         tap(resp => {
-          if (isHttpOK(resp)) {
+          if (resp.ok) {
             this.notifications.success('Recording created');
           } else {
             this.notifications.danger(`Request failed (Status ${resp.status})`, resp.statusText)
           }
         }),
-        map(isHttpOK),
+        map(resp => resp.ok),
         first(),
       )
     ));
@@ -144,11 +144,11 @@ export class ApiService {
         }
       ).pipe(
         tap(resp => {
-          if (!isHttpOK(resp)) {
+          if (!resp.ok) {
             this.notifications.danger(`Request failed (Status ${resp.status})`, resp.statusText)
           }
         }),
-        map(isHttpOK),
+        map(resp => resp.ok),
         first(),
       )
     ));
@@ -164,11 +164,11 @@ export class ApiService {
         }
       ).pipe(
         tap(resp => {
-          if (!isHttpOK(resp)) {
+          if (!resp.ok) {
             this.notifications.danger(`Request failed (Status ${resp.status})`, resp.statusText)
           }
         }),
-        map(isHttpOK),
+        map(resp => resp.ok),
         first(),
       )
     ));
@@ -183,11 +183,11 @@ export class ApiService {
         }
       ).pipe(
         tap(resp => {
-          if (!isHttpOK(resp)) {
+          if (!resp.ok) {
             this.notifications.danger(`Request failed (Status ${resp.status})`, resp.statusText)
           }
         }),
-        map(isHttpOK),
+        map(resp => resp.ok),
         first(),
       )
     ));
@@ -198,11 +198,11 @@ export class ApiService {
       method: 'DELETE'
     }).pipe(
       tap(resp => {
-        if (!isHttpOK(resp)) {
+        if (!resp.ok) {
           this.notifications.danger(`Request failed (Status ${resp.status})`, resp.statusText)
         }
       }),
-      map(isHttpOK),
+      map(resp => resp.ok),
       first(),
     );
   }
@@ -216,11 +216,11 @@ export class ApiService {
         }
       ).pipe(
         tap(resp => {
-          if (!isHttpOK(resp)) {
+          if (!resp.ok) {
             this.notifications.danger(`Request failed (Status ${resp.status})`, resp.statusText)
           }
         }),
-        map(isHttpOK),
+        map(resp => resp.ok),
         first()
       )
     ));
@@ -376,8 +376,6 @@ export class ApiService {
   }
 
 }
-
-const isHttpOK = (resp: Response): boolean => 200 <= resp.status && resp.status < 300;
 
 export interface SavedRecording {
   name: string;

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -227,7 +227,7 @@ export class ApiService {
   }
 
   deleteCustomEventTemplate(templateName: string): Observable<void> {
-    return this.sendRequest(`templates/${templateName}`, {
+    return this.sendRequest(`templates/${encodeURIComponent(templateName)}`, {
       method: 'DELETE',
       body: null,
     })

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -160,7 +160,7 @@ export class ApiService {
   }
 
   doGet<T>(path: string): Observable<T> {
-    return this.sendRequest(path, { method: 'GET' }).pipe(map(resp => resp.json()), concatMap(from));
+    return this.sendRequest(path, { method: 'GET' }).pipe(map(resp => resp.json()), concatMap(from), first());
   }
 
   getAuthMethod(): Observable<string> {

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2020 Red Hat, Inc.
- * 
+ *
  * The Universal Permissive License (UPL), Version 1.0
- * 
+ *
  * Subject to the condition set forth below, permission is hereby granted to any
  * person obtaining a copy of this software, associated documentation and/or data
  * (collectively the "Software"), free of charge and under any and all copyright
@@ -10,23 +10,23 @@
  * licensable by each licensor hereunder covering either (i) the unmodified
  * Software as contributed to or provided by such licensor, or (ii) the Larger
  * Works (as defined below), to deal in both
- * 
+ *
  * (a) the Software, and
  * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
  * one is included with the Software (each a "Larger Work" to which the Software
  * is contributed by such licensors),
- * 
+ *
  * without restriction, including without limitation the rights to copy, create
  * derivative works of, display, perform, and distribute the Software and make,
  * use, sell, offer for sale, import, export, have made, and have sold the
  * Software and the Larger Work(s), and to sublicense the foregoing rights on
  * either these or other terms.
- * 
+ *
  * This license is subject to the following condition:
  * The above copyright notice and either this complete permission notice or at
  * a minimum a reference to the UPL must be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -142,6 +142,23 @@ export class ApiService {
           })
         )
     ));
+  }
+
+  doGet<T>(path: string): Observable<T> {
+    return this.getToken().pipe(
+      combineLatest(this.getAuthMethod()),
+      first(),
+      concatMap(auths =>
+        fromFetch(`${this.authority}/api/v1/${path}`, {
+          credentials: 'include',
+          mode: 'cors',
+          method: 'GET',
+          headers: this.getHeaders(auths[0], auths[1])
+        })
+      ),
+      map(resp => resp.json()),
+      concatMap(from)
+    );
   }
 
   getAuthMethod(): Observable<string> {

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -144,7 +144,7 @@ export class ApiService {
     ));
   }
 
-  doGet<T>(path: string): Observable<T> {
+  sendRequest(path: string, config?: RequestInit): Observable<Response> {
     return this.getToken().pipe(
       combineLatest(this.getAuthMethod()),
       first(),
@@ -152,13 +152,15 @@ export class ApiService {
         fromFetch(`${this.authority}/api/v1/${path}`, {
           credentials: 'include',
           mode: 'cors',
-          method: 'GET',
-          headers: this.getHeaders(auths[0], auths[1])
+          headers: this.getHeaders(auths[0], auths[1]),
+          ...config,
         })
-      ),
-      map(resp => resp.json()),
-      concatMap(from)
+      )
     );
+  }
+
+  doGet<T>(path: string): Observable<T> {
+    return this.sendRequest(path, { method: 'GET' }).pipe(map(resp => resp.json()), concatMap(from));
   }
 
   getAuthMethod(): Observable<string> {

--- a/src/app/Shared/Services/CommandChannel.service.tsx
+++ b/src/app/Shared/Services/CommandChannel.service.tsx
@@ -36,11 +36,10 @@
  * SOFTWARE.
  */
 import { Notifications } from '@app/Notifications/Notifications';
-import { nanoid } from 'nanoid';
 import { BehaviorSubject, combineLatest, from, Observable, ReplaySubject, Subject, forkJoin, throwError } from 'rxjs';
 import { fromFetch } from 'rxjs/fetch';
 import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
-import { concatMap, filter, first, map } from 'rxjs/operators';
+import { concatMap, first } from 'rxjs/operators';
 import { ApiService } from './Api.service';
 
 export class CommandChannel {

--- a/src/app/Shared/Services/CommandChannel.service.tsx
+++ b/src/app/Shared/Services/CommandChannel.service.tsx
@@ -64,7 +64,7 @@ export class CommandChannel {
         (url: any) => this.clientUrlSubject.next(url.clientUrl),
         (err: any) => this.logError('Client URL configuration', err)
       );
-    
+
     const getDatasourceURL = fromFetch(`${this.apiSvc.authority}/api/v1/grafana_datasource_url`)
     .pipe(concatMap(resp => from(resp.json())));
     const getDashboardURL = fromFetch(`${this.apiSvc.authority}/api/v1/grafana_dashboard_url`)
@@ -72,7 +72,7 @@ export class CommandChannel {
 
     fromFetch(`${this.apiSvc.authority}/health`)
       .pipe(
-        concatMap(resp => from(resp.json())), 
+        concatMap(resp => from(resp.json())),
         concatMap((jsonResp: any) => {
           if (jsonResp.dashboardAvailable && jsonResp.datasourceAvailable) {
             return forkJoin([getDatasourceURL, getDashboardURL]);
@@ -176,37 +176,6 @@ export class CommandChannel {
 
   target(): Observable<string> {
     return this.targetSubject.asObservable();
-  }
-
-  // "control" messages, which do not operate upon a Target JVM
-  sendControlMessage(command: string, args: string[] = [], id: string = this.createMessageId()): Observable<string> {
-    const subj = new Subject<string>();
-    this.ready.pipe(
-      first(),
-      map(ready => ready ? id : '')
-    ).subscribe(i => {
-      if (!!i && this.ws) {
-        this.ws.next({ id, command, args });
-      } else if (this.ws) {
-        this.logError('Attempted to send control message when command channel was not ready', { id, command, args });
-      } else {
-        this.logError('Attempted to send control message when command channel was not initialized', { id, command, args });
-      }
-      subj.next(i);
-    });
-    return subj.asObservable();
-  }
-
-  createMessageId(): string {
-    return nanoid();
-  }
-
-  onResponse(command: string): Observable<ResponseMessage<any>> {
-    return this.messages
-      .asObservable()
-      .pipe(
-        filter(m => m.commandName === command)
-      );
   }
 
   private logError(title: string, err: any): void {

--- a/src/app/Shared/Services/CommandChannel.service.tsx
+++ b/src/app/Shared/Services/CommandChannel.service.tsx
@@ -202,25 +202,6 @@ export class CommandChannel {
     return subj.asObservable();
   }
 
-  // "targeted" messages, ie those which operate upon a specific Target JVM
-  sendMessage(command: string, args: string[] = [], id: string = this.createMessageId()): Observable<string> {
-    const subj = new Subject<string>();
-    combineLatest(this.target(), this.ready.pipe(
-      first(),
-      map(ready => ready ? id : '')
-    )).subscribe(([target, id]) => {
-      if (!!id && this.ws) {
-        this.ws.next({ id, command, args: [target, ...args] });
-      } else if (this.ws) {
-        this.logError('Attempted to send message when command channel was not ready', { id, command, args });
-      } else {
-        this.logError('Attempted to send message when command channel was not initialized', { id, command, args });
-      }
-      subj.next(id);
-    });
-    return subj.asObservable();
-  }
-
   createMessageId(): string {
     return nanoid();
   }

--- a/src/app/Shared/Services/CommandChannel.service.tsx
+++ b/src/app/Shared/Services/CommandChannel.service.tsx
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2020 Red Hat, Inc.
- * 
+ *
  * The Universal Permissive License (UPL), Version 1.0
- * 
+ *
  * Subject to the condition set forth below, permission is hereby granted to any
  * person obtaining a copy of this software, associated documentation and/or data
  * (collectively the "Software"), free of charge and under any and all copyright
@@ -10,23 +10,23 @@
  * licensable by each licensor hereunder covering either (i) the unmodified
  * Software as contributed to or provided by such licensor, or (ii) the Larger
  * Works (as defined below), to deal in both
- * 
+ *
  * (a) the Software, and
  * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
  * one is included with the Software (each a "Larger Work" to which the Software
  * is contributed by such licensors),
- * 
+ *
  * without restriction, including without limitation the rights to copy, create
  * derivative works of, display, perform, and distribute the Software and make,
  * use, sell, offer for sale, import, export, have made, and have sold the
  * Software and the Larger Work(s), and to sublicense the foregoing rights on
  * either these or other terms.
- * 
+ *
  * This license is subject to the following condition:
  * The above copyright notice and either this complete permission notice or at
  * a minimum a reference to the UPL must be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -41,6 +41,7 @@ import { BehaviorSubject, combineLatest, from, Observable, ReplaySubject, Subjec
 import { fromFetch } from 'rxjs/fetch';
 import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
 import { concatMap, filter, first, map } from 'rxjs/operators';
+import { TargetService } from './Target.service';
 import { ApiService } from './Api.service';
 
 export class CommandChannel {
@@ -53,9 +54,12 @@ export class CommandChannel {
   private readonly clientUrlSubject = new ReplaySubject<string>(1);
   private readonly grafanaDatasourceUrlSubject = new ReplaySubject<string>(1);
   private readonly grafanaDashboardUrlSubject = new ReplaySubject<string>(1);
-  private readonly targetSubject = new ReplaySubject<string>(1);
 
-  constructor(apiSvc: ApiService, private readonly notifications: Notifications) {
+  constructor(
+    private readonly targetSvc: TargetService,
+    apiSvc: ApiService,
+    private readonly notifications: Notifications
+  ) {
     this.apiSvc = apiSvc;
 
     fromFetch(`${this.apiSvc.authority}/api/v1/clienturl`)
@@ -171,11 +175,11 @@ export class CommandChannel {
   }
 
   setTarget(targetId: string): void {
-    this.targetSubject.next(targetId);
+    this.targetSvc.setTarget(targetId);
   }
 
   target(): Observable<string> {
-    return this.targetSubject.asObservable();
+    return this.targetSvc.target();
   }
 
   private logError(title: string, err: any): void {

--- a/src/app/Shared/Services/CommandChannel.service.tsx
+++ b/src/app/Shared/Services/CommandChannel.service.tsx
@@ -94,16 +94,11 @@ export class CommandChannel {
         },
         err => this.logError('Grafana configuration not found', err)
       );
-    
-    this.onResponse('list-saved').pipe(
-      first(),
-      map(msg => msg.status === 0)
-    ).subscribe(listSavedEnabled => this.archiveEnabled.next(listSavedEnabled));
 
-    this.isReady().pipe(
-      filter(ready => !!ready)
-    ).subscribe(() => {
-      this.sendControlMessage('list-saved');
+    apiSvc.doGet('recordings').subscribe(() => {
+      this.archiveEnabled.next(true);
+    }, () => {
+      this.archiveEnabled.next(false);
     });
 
     this.clientUrl().pipe(

--- a/src/app/Shared/Services/CommandChannel.service.tsx
+++ b/src/app/Shared/Services/CommandChannel.service.tsx
@@ -41,7 +41,6 @@ import { BehaviorSubject, combineLatest, from, Observable, ReplaySubject, Subjec
 import { fromFetch } from 'rxjs/fetch';
 import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
 import { concatMap, filter, first, map } from 'rxjs/operators';
-import { TargetService } from './Target.service';
 import { ApiService } from './Api.service';
 
 export class CommandChannel {
@@ -56,7 +55,6 @@ export class CommandChannel {
   private readonly grafanaDashboardUrlSubject = new ReplaySubject<string>(1);
 
   constructor(
-    private readonly targetSvc: TargetService,
     apiSvc: ApiService,
     private readonly notifications: Notifications
   ) {
@@ -166,20 +164,8 @@ export class CommandChannel {
     return this.ready.asObservable();
   }
 
-  isConnected(): Observable<boolean> {
-    return this.target().pipe(map(t => !!t));
-  }
-
   isArchiveEnabled(): Observable<boolean> {
     return this.archiveEnabled.asObservable();
-  }
-
-  setTarget(targetId: string): void {
-    this.targetSvc.setTarget(targetId);
-  }
-
-  target(): Observable<string> {
-    return this.targetSvc.target();
   }
 
   private logError(title: string, err: any): void {

--- a/src/app/Shared/Services/Report.service.tsx
+++ b/src/app/Shared/Services/Report.service.tsx
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2020 Red Hat, Inc.
- * 
+ *
  * The Universal Permissive License (UPL), Version 1.0
- * 
+ *
  * Subject to the condition set forth below, permission is hereby granted to any
  * person obtaining a copy of this software, associated documentation and/or data
  * (collectively the "Software"), free of charge and under any and all copyright
@@ -10,23 +10,23 @@
  * licensable by each licensor hereunder covering either (i) the unmodified
  * Software as contributed to or provided by such licensor, or (ii) the Larger
  * Works (as defined below), to deal in both
- * 
+ *
  * (a) the Software, and
  * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
  * one is included with the Software (each a "Larger Work" to which the Software
  * is contributed by such licensors),
- * 
+ *
  * without restriction, including without limitation the rights to copy, create
  * derivative works of, display, perform, and distribute the Software and make,
  * use, sell, offer for sale, import, export, have made, and have sold the
  * Software and the Larger Work(s), and to sublicense the foregoing rights on
  * either these or other terms.
- * 
+ *
  * This license is subject to the following condition:
  * The above copyright notice and either this complete permission notice or at
  * a minimum a reference to the UPL must be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -37,12 +37,12 @@
  */
 import { Observable, of, throwError } from 'rxjs';
 import { fromFetch } from 'rxjs/fetch';
-import { combineLatest, concatMap, map, mergeMap, tap } from 'rxjs/operators';
+import { combineLatest, concatMap, mergeMap, tap } from 'rxjs/operators';
 import { ApiService, isActiveRecording, RecordingState, SavedRecording } from './Api.service';
 
 export class ReportService {
 
-  private readonly reports: Map<SavedRecording, string> = new Map();
+  private readonly reports: Map<SavedRecording, string> = new window.Map();
 
   constructor(private api: ApiService) { }
 

--- a/src/app/Shared/Services/Services.tsx
+++ b/src/app/Shared/Services/Services.tsx
@@ -37,7 +37,7 @@
  */
 import * as React from 'react';
 import { NotificationsInstance } from '@app/Notifications/Notifications';
-import { TargetService } from './Target.service';
+import { TargetService, TargetInstance } from './Target.service';
 import { ApiService } from './Api.service';
 import { CommandChannel } from './CommandChannel.service';
 import { ReportService } from './Report.service';
@@ -49,12 +49,11 @@ export interface Services {
   reports: ReportService;
 }
 
-const target = new TargetService();
-const api = new ApiService(NotificationsInstance);
+const api = new ApiService(TargetInstance, NotificationsInstance);
 const commandChannel = new CommandChannel(api, NotificationsInstance);
 const reports = new ReportService(api);
 
-const defaultServices: Services = { target, api, commandChannel, reports };
+const defaultServices: Services = { target: TargetInstance, api, commandChannel, reports };
 
 const ServiceContext: React.Context<Services> = React.createContext(defaultServices);
 

--- a/src/app/Shared/Services/Services.tsx
+++ b/src/app/Shared/Services/Services.tsx
@@ -51,7 +51,7 @@ export interface Services {
 
 const target = new TargetService();
 const api = new ApiService(NotificationsInstance);
-const commandChannel = new CommandChannel(target, api, NotificationsInstance);
+const commandChannel = new CommandChannel(api, NotificationsInstance);
 const reports = new ReportService(api);
 
 const defaultServices: Services = { target, api, commandChannel, reports };

--- a/src/app/Shared/Services/Services.tsx
+++ b/src/app/Shared/Services/Services.tsx
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2020 Red Hat, Inc.
- * 
+ *
  * The Universal Permissive License (UPL), Version 1.0
- * 
+ *
  * Subject to the condition set forth below, permission is hereby granted to any
  * person obtaining a copy of this software, associated documentation and/or data
  * (collectively the "Software"), free of charge and under any and all copyright
@@ -10,23 +10,23 @@
  * licensable by each licensor hereunder covering either (i) the unmodified
  * Software as contributed to or provided by such licensor, or (ii) the Larger
  * Works (as defined below), to deal in both
- * 
+ *
  * (a) the Software, and
  * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
  * one is included with the Software (each a "Larger Work" to which the Software
  * is contributed by such licensors),
- * 
+ *
  * without restriction, including without limitation the rights to copy, create
  * derivative works of, display, perform, and distribute the Software and make,
  * use, sell, offer for sale, import, export, have made, and have sold the
  * Software and the Larger Work(s), and to sublicense the foregoing rights on
  * either these or other terms.
- * 
+ *
  * This license is subject to the following condition:
  * The above copyright notice and either this complete permission notice or at
  * a minimum a reference to the UPL must be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -37,21 +37,24 @@
  */
 import * as React from 'react';
 import { NotificationsInstance } from '@app/Notifications/Notifications';
+import { TargetService } from './Target.service';
 import { ApiService } from './Api.service';
 import { CommandChannel } from './CommandChannel.service';
 import { ReportService } from './Report.service';
 
 export interface Services {
+  target: TargetService,
   api: ApiService;
   commandChannel: CommandChannel;
   reports: ReportService;
 }
 
+const target = new TargetService();
 const api = new ApiService(NotificationsInstance);
-const commandChannel = new CommandChannel(api, NotificationsInstance);
+const commandChannel = new CommandChannel(target, api, NotificationsInstance);
 const reports = new ReportService(api);
 
-const defaultServices: Services = { api, commandChannel, reports };
+const defaultServices: Services = { target, api, commandChannel, reports };
 
 const ServiceContext: React.Context<Services> = React.createContext(defaultServices);
 

--- a/src/app/Shared/Services/Services.tsx
+++ b/src/app/Shared/Services/Services.tsx
@@ -43,7 +43,7 @@ import { CommandChannel } from './CommandChannel.service';
 import { ReportService } from './Report.service';
 
 export interface Services {
-  target: TargetService,
+  target: TargetService;
   api: ApiService;
   commandChannel: CommandChannel;
   reports: ReportService;

--- a/src/app/Shared/Services/Target.service.tsx
+++ b/src/app/Shared/Services/Target.service.tsx
@@ -1,8 +1,8 @@
-import { Observable, Subject, ReplaySubject } from 'rxjs';
+import { Observable, Subject, BehaviorSubject } from 'rxjs';
 
 export class TargetService {
 
-  private readonly subj: Subject<string> = new ReplaySubject();
+  private readonly subj: Subject<string> = new BehaviorSubject('');
 
   setTarget(target: string): void {
     this.subj.next(target);

--- a/src/app/Shared/Services/Target.service.tsx
+++ b/src/app/Shared/Services/Target.service.tsx
@@ -1,6 +1,6 @@
 import { Observable, Subject, BehaviorSubject } from 'rxjs';
 
-export class TargetService {
+class TargetService {
 
   private readonly subj: Subject<string> = new BehaviorSubject('');
 
@@ -13,3 +13,7 @@ export class TargetService {
   }
 
 }
+
+const TargetInstance = new TargetService();
+
+export { TargetService, TargetInstance }

--- a/src/app/Shared/Services/Target.service.tsx
+++ b/src/app/Shared/Services/Target.service.tsx
@@ -1,0 +1,15 @@
+import { Observable, Subject, ReplaySubject } from 'rxjs';
+
+export class TargetService {
+
+  private readonly subj: Subject<string> = new ReplaySubject();
+
+  setTarget(target: string): void {
+    this.subj.next(target);
+  }
+
+  target(): Observable<string> {
+    return this.subj.asObservable();
+  }
+
+}

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -40,7 +40,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { Button, Card, CardActions, CardBody, CardHeader, CardHeaderMain, Grid, GridItem, Select, SelectOption, SelectVariant, Text, TextVariants } from '@patternfly/react-core';
 import { ContainerNodeIcon, Spinner2Icon } from '@patternfly/react-icons';
-import { filter, first, map } from 'rxjs/operators';
+import { filter, first } from 'rxjs/operators';
 
 export interface TargetSelectProps {
   isCompact?: boolean;
@@ -87,8 +87,7 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
     if (isPlaceholder) {
       context.target.setTarget('');
     } else {
-      let identifier = selection.connectUrl;
-      context.target.setTarget(identifier);
+      context.target.setTarget(selection.connectUrl);
     }
     // FIXME setting the expanded state to false seems to cause an "unmounted component" error
     // in the browser console

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2020 Red Hat, Inc.
- * 
+ *
  * The Universal Permissive License (UPL), Version 1.0
- * 
+ *
  * Subject to the condition set forth below, permission is hereby granted to any
  * person obtaining a copy of this software, associated documentation and/or data
  * (collectively the "Software"), free of charge and under any and all copyright
@@ -10,23 +10,23 @@
  * licensable by each licensor hereunder covering either (i) the unmodified
  * Software as contributed to or provided by such licensor, or (ii) the Larger
  * Works (as defined below), to deal in both
- * 
+ *
  * (a) the Software, and
  * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
  * one is included with the Software (each a "Larger Work" to which the Software
  * is contributed by such licensors),
- * 
+ *
  * without restriction, including without limitation the rights to copy, create
  * derivative works of, display, perform, and distribute the Software and make,
  * use, sell, offer for sale, import, export, have made, and have sold the
  * Software and the Larger Work(s), and to sublicense the foregoing rights on
  * either these or other terms.
- * 
+ *
  * This license is subject to the following condition:
  * The above copyright notice and either this complete permission notice or at
  * a minimum a reference to the UPL must be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -65,7 +65,7 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
   }, [context.commandChannel]);
 
   React.useLayoutEffect(() => {
-    const sub = context.commandChannel.target().subscribe(setSelected);
+    const sub = context.target.target().subscribe(setSelected);
     return () => sub.unsubscribe();
   }, [context.commandChannel]);
 
@@ -79,10 +79,10 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
 
   const onSelect = (evt, selection, isPlaceholder) => {
     if (isPlaceholder) {
-      context.commandChannel.setTarget('');
+      context.target.setTarget('');
     } else {
       let identifier = selection.connectUrl;
-      context.commandChannel.setTarget(identifier);
+      context.target.setTarget(identifier);
     }
     // FIXME setting the expanded state to false seems to cause an "unmounted component" error
     // in the browser console

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -74,7 +74,9 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
   const refreshTargetList = () => {
     setLoading(true);
     addSubscription(
-      context.api.doGet<Target[]>(`targets`).subscribe(targets => {
+      context.api.doGet<Target[]>(`targets`)
+      .pipe(first())
+      .subscribe(targets => {
         setTargets(targets);
         setLoading(false);
       })

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -37,6 +37,7 @@
  */
 import * as React from 'react';
 import { ServiceContext } from '@app/Shared/Services/Services';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { Button, Card, CardActions, CardBody, CardHeader, CardHeaderMain, Grid, GridItem, Select, SelectOption, SelectVariant, Text, TextVariants } from '@patternfly/react-core';
 import { ContainerNodeIcon, Spinner2Icon } from '@patternfly/react-icons';
 import { filter, first, map } from 'rxjs/operators';
@@ -56,6 +57,7 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
   const [targets, setTargets] = React.useState([] as Target[]);
   const [expanded, setExpanded] = React.useState(false);
   const [isLoading, setLoading] = React.useState(true);
+  const addSubscription = useSubscriptions();
 
   React.useEffect(() => {
     const sub = context.commandChannel.isReady()
@@ -71,10 +73,12 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
 
   const refreshTargetList = () => {
     setLoading(true);
-    context.api.doGet<Target[]>(`targets`).subscribe(targets => {
-      setTargets(targets);
-      setLoading(false);
-    });
+    addSubscription(
+      context.api.doGet<Target[]>(`targets`).subscribe(targets => {
+        setTargets(targets);
+        setLoading(false);
+      })
+    );
   };
 
   const onSelect = (evt, selection, isPlaceholder) => {

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -53,17 +53,9 @@ interface Target {
 export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) => {
   const context = React.useContext(ServiceContext);
   const [selected, setSelected] = React.useState('');
-  const [targets, setTargets] = React.useState([]);
+  const [targets, setTargets] = React.useState([] as Target[]);
   const [expanded, setExpanded] = React.useState(false);
   const [isLoading, setLoading] = React.useState(true);
-
-  React.useEffect(() => {
-    const sub = context.commandChannel.onResponse('scan-targets').pipe(map(msg => msg.payload)).subscribe(targets => {
-      setTargets(targets);
-      setLoading(false);
-    });
-    return () => sub.unsubscribe();
-  }, [context.commandChannel]);
 
   React.useEffect(() => {
     const sub = context.commandChannel.isReady()
@@ -79,7 +71,10 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
 
   const refreshTargetList = () => {
     setLoading(true);
-    context.commandChannel.sendControlMessage('scan-targets')
+    context.api.doGet<Target[]>(`targets`).subscribe(targets => {
+      setTargets(targets);
+      setLoading(false);
+    });
   };
 
   const onSelect = (evt, selection, isPlaceholder) => {

--- a/src/app/TargetView/TargetView.tsx
+++ b/src/app/TargetView/TargetView.tsx
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2020 Red Hat, Inc.
- * 
+ *
  * The Universal Permissive License (UPL), Version 1.0
- * 
+ *
  * Subject to the condition set forth below, permission is hereby granted to any
  * person obtaining a copy of this software, associated documentation and/or data
  * (collectively the "Software"), free of charge and under any and all copyright
@@ -10,23 +10,23 @@
  * licensable by each licensor hereunder covering either (i) the unmodified
  * Software as contributed to or provided by such licensor, or (ii) the Larger
  * Works (as defined below), to deal in both
- * 
+ *
  * (a) the Software, and
  * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
  * one is included with the Software (each a "Larger Work" to which the Software
  * is contributed by such licensors),
- * 
+ *
  * without restriction, including without limitation the rights to copy, create
  * derivative works of, display, perform, and distribute the Software and make,
  * use, sell, offer for sale, import, export, have made, and have sold the
  * Software and the Larger Work(s), and to sublicense the foregoing rights on
  * either these or other terms.
- * 
+ *
  * This license is subject to the following condition:
  * The above copyright notice and either this complete permission notice or at
  * a minimum a reference to the UPL must be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -53,7 +53,7 @@ export const TargetView: React.FunctionComponent<TargetViewProps> = (props) => {
   const [connected, setConnected] = React.useState(false);
 
   React.useLayoutEffect(() => {
-    const sub = context.commandChannel.target().pipe(map(t => !!t)).subscribe(setConnected);
+    const sub = context.target.target().pipe(map(t => !!t)).subscribe(setConnected);
     return () => sub.unsubscribe();
   }, [context.commandChannel])
 

--- a/src/app/utils/useSubscriptions.ts
+++ b/src/app/utils/useSubscriptions.ts
@@ -39,12 +39,17 @@ import * as React from 'react';
 import { Subscription } from 'rxjs';
 
 export function useSubscriptions() {
-  const [subscriptions, setSubscriptions] = React.useState([] as Subscription[]);
+  const subsRef = React.useRef([] as Subscription[]);
+  const [subscriptions, setSubscriptions] = React.useState(subsRef.current);
 
-  React.useEffect(() => () => subscriptions.forEach((s: Subscription): void => s.unsubscribe()), []);
+  React.useEffect(() => () => subsRef.current.forEach((s: Subscription): void => s.unsubscribe()), []);
 
   const addSubscription = (sub: Subscription): void => {
-    setSubscriptions((subs: Subscription[]): Subscription[] => subs.concat([sub]));
+    setSubscriptions((subs: Subscription[]): Subscription[] => {
+      const result = subs.concat([sub]);
+      subsRef.current = result;
+      return result;
+    });
   };
 
   return addSubscription;

--- a/src/app/utils/useSubscriptions.ts
+++ b/src/app/utils/useSubscriptions.ts
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2020 Red Hat, Inc.
- * 
+ *
  * The Universal Permissive License (UPL), Version 1.0
- * 
+ *
  * Subject to the condition set forth below, permission is hereby granted to any
  * person obtaining a copy of this software, associated documentation and/or data
  * (collectively the "Software"), free of charge and under any and all copyright
@@ -10,23 +10,23 @@
  * licensable by each licensor hereunder covering either (i) the unmodified
  * Software as contributed to or provided by such licensor, or (ii) the Larger
  * Works (as defined below), to deal in both
- * 
+ *
  * (a) the Software, and
  * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
  * one is included with the Software (each a "Larger Work" to which the Software
  * is contributed by such licensors),
- * 
+ *
  * without restriction, including without limitation the rights to copy, create
  * derivative works of, display, perform, and distribute the Software and make,
  * use, sell, offer for sale, import, export, have made, and have sold the
  * Software and the Larger Work(s), and to sublicense the foregoing rights on
  * either these or other terms.
- * 
+ *
  * This license is subject to the following condition:
  * The above copyright notice and either this complete permission notice or at
  * a minimum a reference to the UPL must be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -35,22 +35,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import { Observable, Subject, BehaviorSubject } from 'rxjs';
+import * as React from 'react';
+import { Subscription } from 'rxjs';
 
-class TargetService {
+export function useSubscriptions() {
+  const [subscriptions, setSubscriptions] = React.useState([] as Subscription[]);
 
-  private readonly subj: Subject<string> = new BehaviorSubject('');
+  React.useEffect(() => () => subscriptions.forEach((s: Subscription): void => s.unsubscribe()), []);
 
-  setTarget(target: string): void {
-    this.subj.next(target);
-  }
+  const addSubscription = (sub: Subscription): void => {
+    setSubscriptions((subs: Subscription[]): Subscription[] => subs.concat([sub]));
+  };
 
-  target(): Observable<string> {
-    return this.subj.asObservable();
-  }
-
+  return addSubscription;
 }
-
-const TargetInstance = new TargetService();
-
-export { TargetService, TargetInstance }


### PR DESCRIPTION
See rh-jmc-team/container-jfr#222

This PR replaces all uses of the command channel with HTTP calls instead, in preparation for support for RJMX authentication (rh-jmc-team/container-jfr#225) to come later.