### PR TITLE
Fix bug preventing archived recording uploads

### DIFF
--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -211,7 +211,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
           <DataListItemCells
             dataListCells={listColumns}
           />
-          <RecordingActions index={props.index} recording={props.recording} />
+          <RecordingActions index={props.index} recording={props.recording} uploadFn={() => context.api.uploadActiveRecordingToGrafana(props.recording.name)} />
         </DataListItemRow>
         <DataListContent
           aria-label="Content Details"
@@ -294,6 +294,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
 export interface RecordingActionsProps {
   index: number;
   recording: Recording;
+  uploadFn: () => Observable<boolean>;
 }
 
 export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = (props) => {
@@ -314,7 +315,7 @@ export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = 
   const grafanaUpload = () => {
     notifications.info('Upload Started', `Recording "${props.recording.name}" uploading...`);
     addSubscription(
-      context.api.uploadRecordingToGrafana(props.recording.name)
+      props.uploadFn()
       .pipe(first())
       .subscribe(success => {
         if (success) {

--- a/src/app/RecordingList/ArchivedRecordingsList.tsx
+++ b/src/app/RecordingList/ArchivedRecordingsList.tsx
@@ -147,7 +147,7 @@ export const ArchivedRecordingsList: React.FunctionComponent<ArchivedRecordingsL
               </DataListCell>
             ]}
           />
-          <RecordingActions recording={props.recording} index={props.index} />
+          <RecordingActions recording={props.recording} index={props.index} uploadFn={() => context.api.uploadArchivedRecordingToGrafana(props.recording.name)} />
         </DataListItemRow>
         <DataListContent
           aria-label="Content Details"

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -107,8 +107,6 @@ export class ApiService {
           tap(resp => {
             if (resp.ok) {
               this.notifications.success('Recording created');
-            } else {
-              this.notifications.danger(`Request failed (Status ${resp.status})`, resp.statusText)
             }
           }),
           map(resp => resp.ok),
@@ -124,8 +122,6 @@ export class ApiService {
         tap(resp => {
           if (resp.ok) {
             this.notifications.success('Recording created');
-          } else {
-            this.notifications.danger(`Request failed (Status ${resp.status})`, resp.statusText)
           }
         }),
         map(resp => resp.ok),
@@ -143,11 +139,6 @@ export class ApiService {
           body: 'SAVE',
         }
       ).pipe(
-        tap(resp => {
-          if (!resp.ok) {
-            this.notifications.danger(`Request failed (Status ${resp.status})`, resp.statusText)
-          }
-        }),
         map(resp => resp.ok),
         first(),
       )
@@ -163,11 +154,6 @@ export class ApiService {
           body: 'STOP',
         }
       ).pipe(
-        tap(resp => {
-          if (!resp.ok) {
-            this.notifications.danger(`Request failed (Status ${resp.status})`, resp.statusText)
-          }
-        }),
         map(resp => resp.ok),
         first(),
       )
@@ -182,11 +168,6 @@ export class ApiService {
           method: 'DELETE',
         }
       ).pipe(
-        tap(resp => {
-          if (!resp.ok) {
-            this.notifications.danger(`Request failed (Status ${resp.status})`, resp.statusText)
-          }
-        }),
         map(resp => resp.ok),
         first(),
       )
@@ -197,11 +178,6 @@ export class ApiService {
     return this.sendRequest(`recordings/${encodeURIComponent(recordingName)}`, {
       method: 'DELETE'
     }).pipe(
-      tap(resp => {
-        if (!resp.ok) {
-          this.notifications.danger(`Request failed (Status ${resp.status})`, resp.statusText)
-        }
-      }),
       map(resp => resp.ok),
       first(),
     );
@@ -215,11 +191,6 @@ export class ApiService {
           method: 'POST',
         }
       ).pipe(
-        tap(resp => {
-          if (!resp.ok) {
-            this.notifications.danger(`Request failed (Status ${resp.status})`, resp.statusText)
-          }
-        }),
         map(resp => resp.ok),
         first()
       )
@@ -233,11 +204,6 @@ export class ApiService {
           method: 'POST',
         }
       ).pipe(
-        tap(resp => {
-          if (!resp.ok) {
-            this.notifications.danger(`Request failed (Status ${resp.status})`, resp.statusText)
-          }
-        }),
         map(resp => resp.ok),
         first()
       )
@@ -306,7 +272,14 @@ export class ApiService {
         mode: 'cors',
         headers: this.getHeaders(auths[0], auths[1]),
       })
-      .pipe(concatMap(resp => resp.blob()))
+      .pipe(
+        tap(resp => {
+          if (!resp.ok) {
+            this.notifications.danger(`Request failed (Status ${resp.status})`, resp.statusText)
+          }
+        }),
+        concatMap(resp => resp.blob()),
+      )
       .subscribe(resp =>
         this.downloadFile(
           `${recording.name}.report.html`,
@@ -326,7 +299,14 @@ export class ApiService {
         mode: 'cors',
         headers: this.getHeaders(auths[0], auths[1]),
       })
-      .pipe(concatMap(resp => resp.blob()))
+      .pipe(
+        tap(resp => {
+          if (!resp.ok) {
+            this.notifications.danger(`Request failed (Status ${resp.status})`, resp.statusText)
+          }
+        }),
+        concatMap(resp => resp.blob()),
+      )
       .subscribe(resp =>
         this.downloadFile(
           recording.name + (recording.name.endsWith('.jfr') ? '' : '.jfr'),
@@ -371,7 +351,12 @@ export class ApiService {
           headers: this.getHeaders(auths[0], auths[1]),
           ...config,
         })
-      )
+      ),
+      tap(resp => {
+        if (!resp.ok) {
+          this.notifications.danger(`Request failed (Status ${resp.status})`, resp.statusText)
+        }
+      }),
     );
   }
 

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -233,6 +233,11 @@ export class ApiService {
           method: 'POST',
         }
       ).pipe(
+        tap(resp => {
+          if (!resp.ok) {
+            this.notifications.danger(`Request failed (Status ${resp.status})`, resp.statusText)
+          }
+        }),
         map(resp => resp.ok),
         first()
       )

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -207,7 +207,7 @@ export class ApiService {
     );
   }
 
-  uploadRecordingToGrafana(recordingName: string): Observable<boolean> {
+  uploadActiveRecordingToGrafana(recordingName: string): Observable<boolean> {
     return this.target.target().pipe(concatMap(targetId =>
       this.sendRequest(
         `targets/${encodeURIComponent(targetId)}/recordings/${encodeURIComponent(recordingName)}/upload`,
@@ -224,6 +224,19 @@ export class ApiService {
         first()
       )
     ));
+  }
+
+  uploadArchivedRecordingToGrafana(recordingName: string): Observable<boolean> {
+    return this.sendRequest(
+        `recordings/${encodeURIComponent(recordingName)}/upload`,
+        {
+          method: 'POST',
+        }
+      ).pipe(
+        map(resp => resp.ok),
+        first()
+      )
+    ;
   }
 
   deleteCustomEventTemplate(templateName: string): Observable<void> {


### PR DESCRIPTION
A previous commit refactored the ApiService in a way that caused all
upload requests to use the HTTP API path as if they were all active
recordings. This re-adds a differentiation in the service implementation
between archived and active recordings to reflect the different HTTP API
paths for uploading either to a jfr-datasource.

Fixes #119