### PR TITLE
Only send recording options that are relevant (not disabled)

### DIFF
--- a/src/app/CreateRecording/CustomRecordingForm.tsx
+++ b/src/app/CreateRecording/CustomRecordingForm.tsx
@@ -150,8 +150,8 @@ export const CustomRecordingForm = (props) => {
     }
     const options: RecordingOptions = {
       toDisk: toDisk,
-      maxAge: maxAge * maxAgeUnits,
-      maxSize: maxSize * maxSizeUnits 
+      maxAge: toDisk? continuous? maxAge * maxAgeUnits : undefined : undefined,
+      maxSize: toDisk? maxSize * maxSizeUnits : undefined
     }
     const recordingAttributes: RecordingAttributes = {
       name: recordingName,


### PR DESCRIPTION
There could be situations where a recording option becomes disabled but its value is still sent. This only sends the relevant recording options in the new recording request. 