### PR TITLE
unify button layout when creating new recordings

### DIFF
--- a/src/app/CreateRecording/SnapshotRecordingForm.tsx
+++ b/src/app/CreateRecording/SnapshotRecordingForm.tsx
@@ -47,7 +47,7 @@ export const SnapshotRecordingForm = (props) => {
   const history = useHistory();
 
   return (<>
-    <Form>
+    <Form isHorizontal>
       <Text component={TextVariants.p}>
         A Snapshot recording is one which contains all information about all
         events that have been captured in the current session by <i>other,&nbsp;


### PR DESCRIPTION
Fixes #124, It seems that the button layout is vertical when creating custom flight recording because it is a horizontal form. By making the snapshot recording horizontal as well at least it makes both button layouts uniform (both are now stacked).