### PR TITLE
Create loading state in recording list views

### DIFF
--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -62,6 +62,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
   const [checkedIndices, setCheckedIndices] = React.useState([] as number[]);
   const [expandedRows, setExpandedRows] = React.useState([] as string[]);
   const [isLoading, setIsLoading] = React.useState(false);
+  const [errorMessage, setErrorMessage] = React.useState('');
   const { url } = useRouteMatch();
 
   const tableColumns: string[] = [
@@ -94,6 +95,12 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
   const handleRecordings = (recordings) => {
     setRecordings(recordings);
     setIsLoading(false);
+    setErrorMessage('');
+  };
+
+  const handleError = (error) => {
+    setIsLoading(false);
+    setErrorMessage(error);
   }
 
   const refreshRecordingList = React.useCallback(() => {
@@ -103,7 +110,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
       .pipe(
         concatMap(target => context.api.doGet<Recording[]>(`targets/${encodeURIComponent(target)}/recordings`)),
         first(),
-      ).subscribe(handleRecordings)
+      ).subscribe(value => handleRecordings(value), err => handleError(err))
     );
   }, [addSubscription, context.target, context.api]);
 
@@ -304,6 +311,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
         isHeaderChecked={headerChecked}
         onHeaderCheck={handleHeaderCheck}
         isLoading = {isLoading}
+        errorMessage = {errorMessage}
     >
       {recordingRows}
     </RecordingsDataTable>

--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -62,7 +62,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
   const [checkedIndices, setCheckedIndices] = React.useState([] as number[]);
   const [expandedRows, setExpandedRows] = React.useState([] as string[]);
   const [isLoading, setIsLoading] = React.useState(false);
-  const [errorMessage, setErrorMessage] = React.useState('');
+  const [isConnectionError, setIsConnectionError] = React.useState(false);
   const { url } = useRouteMatch();
 
   const tableColumns: string[] = [
@@ -95,12 +95,12 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
   const handleRecordings = (recordings) => {
     setRecordings(recordings);
     setIsLoading(false);
-    setErrorMessage('');
+    setIsConnectionError(false);
   };
 
   const handleError = (error) => {
     setIsLoading(false);
-    setErrorMessage(error);
+    setIsConnectionError(true);
   }
 
   const refreshRecordingList = React.useCallback(() => {
@@ -311,7 +311,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
         isHeaderChecked={headerChecked}
         onHeaderCheck={handleHeaderCheck}
         isLoading = {isLoading}
-        errorMessage = {errorMessage}
+        isConnectionError = {isConnectionError}
     >
       {recordingRows}
     </RecordingsDataTable>

--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -62,7 +62,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
   const [checkedIndices, setCheckedIndices] = React.useState([] as number[]);
   const [expandedRows, setExpandedRows] = React.useState([] as string[]);
   const [isLoading, setIsLoading] = React.useState(false);
-  const [isConnectionError, setIsConnectionError] = React.useState(false);
+  const [errorMessage, setErrorMessage] = React.useState('');
   const { url } = useRouteMatch();
 
   const tableColumns: string[] = [
@@ -95,12 +95,12 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
   const handleRecordings = (recordings) => {
     setRecordings(recordings);
     setIsLoading(false);
-    setIsConnectionError(false);
+    setErrorMessage('');
   };
 
   const handleError = (error) => {
     setIsLoading(false);
-    setIsConnectionError(true);
+    setErrorMessage(error.message);
   }
 
   const refreshRecordingList = React.useCallback(() => {
@@ -311,7 +311,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
         isHeaderChecked={headerChecked}
         onHeaderCheck={handleHeaderCheck}
         isLoading = {isLoading}
-        isConnectionError = {isConnectionError}
+        errorMessage = {errorMessage}
     >
       {recordingRows}
     </RecordingsDataTable>

--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -61,6 +61,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
   const [headerChecked, setHeaderChecked] = React.useState(false);
   const [checkedIndices, setCheckedIndices] = React.useState([] as number[]);
   const [expandedRows, setExpandedRows] = React.useState([] as string[]);
+  const [isLoading, setIsLoading] = React.useState(false);
   const { url } = useRouteMatch();
 
   const tableColumns: string[] = [
@@ -90,13 +91,19 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
     routerHistory.push(`${url}/create`);
   };
 
+  const handleRecordings = (recordings) => {
+    setRecordings(recordings);
+    setIsLoading(false);
+  }
+
   const refreshRecordingList = React.useCallback(() => {
+    setIsLoading(true);
     addSubscription(
       context.target.target()
       .pipe(
         concatMap(target => context.api.doGet<Recording[]>(`targets/${encodeURIComponent(target)}/recordings`)),
         first(),
-      ).subscribe(setRecordings)
+      ).subscribe(handleRecordings)
     );
   }, [addSubscription, context.target, context.api]);
 
@@ -288,7 +295,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
   const recordingRows = React.useMemo(() => {
     return recordings.map((r, idx) => <RecordingRow key={idx} recording={r} index={idx}/>)
   }, [recordings, expandedRows, checkedIndices]);
-
+  
   return (<>
     <RecordingsDataTable
         listTitle="Active Flight Recordings"
@@ -296,6 +303,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
         tableColumns={tableColumns}
         isHeaderChecked={headerChecked}
         onHeaderCheck={handleHeaderCheck}
+        isLoading = {isLoading}
     >
       {recordingRows}
     </RecordingsDataTable>

--- a/src/app/RecordingList/ArchivedRecordingsList.tsx
+++ b/src/app/RecordingList/ArchivedRecordingsList.tsx
@@ -207,6 +207,7 @@ export const ArchivedRecordingsList: React.FunctionComponent<ArchivedRecordingsL
         isHeaderChecked={headerChecked}
         onHeaderCheck={handleHeaderCheck}
         isLoading={isLoading}
+        errorMessage=''
     >
       {
         recordingRows

--- a/src/app/RecordingList/ArchivedRecordingsList.tsx
+++ b/src/app/RecordingList/ArchivedRecordingsList.tsx
@@ -207,7 +207,7 @@ export const ArchivedRecordingsList: React.FunctionComponent<ArchivedRecordingsL
         isHeaderChecked={headerChecked}
         onHeaderCheck={handleHeaderCheck}
         isLoading={isLoading}
-        isConnectionError={false}
+        errorMessage=''
     >
       {
         recordingRows

--- a/src/app/RecordingList/ArchivedRecordingsList.tsx
+++ b/src/app/RecordingList/ArchivedRecordingsList.tsx
@@ -207,7 +207,7 @@ export const ArchivedRecordingsList: React.FunctionComponent<ArchivedRecordingsL
         isHeaderChecked={headerChecked}
         onHeaderCheck={handleHeaderCheck}
         isLoading={isLoading}
-        errorMessage=''
+        isConnectionError={false}
     >
       {
         recordingRows

--- a/src/app/RecordingList/ArchivedRecordingsList.tsx
+++ b/src/app/RecordingList/ArchivedRecordingsList.tsx
@@ -59,8 +59,9 @@ export const ArchivedRecordingsList: React.FunctionComponent<ArchivedRecordingsL
   const [headerChecked, setHeaderChecked] = React.useState(false);
   const [checkedIndices, setCheckedIndices] = React.useState([] as number[]);
   const [expandedRows, setExpandedRows] = React.useState([] as string[]);
-  const addSubscription = useSubscriptions();
   const [showUploadModal, setShowUploadModal] = React.useState(false);
+  const [isLoading, setIsLoading] = React.useState(false);
+  const addSubscription = useSubscriptions();
 
   const tableColumns: string[] = [
     'Name'
@@ -80,11 +81,17 @@ export const ArchivedRecordingsList: React.FunctionComponent<ArchivedRecordingsL
     }
   };
 
+  const handleRecordings = (recordings) => {
+    setRecordings(recordings);
+    setIsLoading(false);
+  }
+
   const refreshRecordingList = React.useCallback(() => {
+    setIsLoading(true);
     addSubscription(
       context.api.doGet<Recording[]>(`recordings`)
       .pipe(first())
-      .subscribe(setRecordings)
+      .subscribe(handleRecordings)
     );
   }, [addSubscription, context.api]);
 
@@ -199,6 +206,7 @@ export const ArchivedRecordingsList: React.FunctionComponent<ArchivedRecordingsL
         tableColumns={tableColumns}
         isHeaderChecked={headerChecked}
         onHeaderCheck={handleHeaderCheck}
+        isLoading={isLoading}
     >
       {
         recordingRows

--- a/src/app/RecordingList/RecordingsDataTable.tsx
+++ b/src/app/RecordingList/RecordingsDataTable.tsx
@@ -45,12 +45,12 @@ export interface RecordingsDataTableProps {
   listTitle: string;
   isHeaderChecked: boolean;
   isLoading: boolean;
-  errorMessage: string;
+  isConnectionError: boolean;
   onHeaderCheck: (checked: boolean) => void;
 }
 
 export const RecordingsDataTable: React.FunctionComponent<RecordingsDataTableProps> = (props) => {
-  if (props.errorMessage != '') {
+  if (props.isConnectionError) {
     return (<>
       <br/>
       <Bullseye>

--- a/src/app/RecordingList/RecordingsDataTable.tsx
+++ b/src/app/RecordingList/RecordingsDataTable.tsx
@@ -45,12 +45,12 @@ export interface RecordingsDataTableProps {
   listTitle: string;
   isHeaderChecked: boolean;
   isLoading: boolean;
-  isConnectionError: boolean;
+  errorMessage: String;
   onHeaderCheck: (checked: boolean) => void;
 }
 
 export const RecordingsDataTable: React.FunctionComponent<RecordingsDataTableProps> = (props) => {
-  if (props.isConnectionError) {
+  if (props.errorMessage != '') {
     return (<>
       <br/>
       <Bullseye>
@@ -58,17 +58,19 @@ export const RecordingsDataTable: React.FunctionComponent<RecordingsDataTablePro
       </Bullseye>
       <Bullseye>
         <Text>
-          Unable to connect
+          Error:&nbsp;{props.errorMessage}
         </Text>
       </Bullseye>
     </>)
-  } else {
-    return props.isLoading? (<>
+  } else if (props.isLoading) {
+    return (<>
       <br/>
       <Bullseye> 
         <Spinner/>
       </Bullseye>
-      </>) : (<>
+      </>) 
+  } else {
+    return (<>
       { props.toolbar }
       <DataList aria-label={props.listTitle}>
         <DataListItem aria-labelledby="table-header-1">

--- a/src/app/RecordingList/RecordingsDataTable.tsx
+++ b/src/app/RecordingList/RecordingsDataTable.tsx
@@ -36,18 +36,24 @@
  * SOFTWARE.
  */
 import * as React from 'react';
-import { DataList, DataListCell, DataListCheck, DataListItem, DataListItemCells, DataListItemRow } from '@patternfly/react-core';
+import { Bullseye, DataList, DataListCell, DataListCheck, DataListItem, DataListItemCells, DataListItemRow, Spinner } from '@patternfly/react-core';
 
 export interface RecordingsDataTableProps {
   toolbar: React.ReactElement;
   tableColumns: string[];
   listTitle: string;
   isHeaderChecked: boolean;
+  isLoading: boolean;
   onHeaderCheck: (checked: boolean) => void;
 }
 
 export const RecordingsDataTable: React.FunctionComponent<RecordingsDataTableProps> = (props) => {
-  return (<>
+  return props.isLoading? (<>
+    <br/>
+    <Bullseye> 
+      <Spinner/>
+    </Bullseye>
+    </>) : (<>
     { props.toolbar }
     <DataList aria-label={props.listTitle}>
       <DataListItem aria-labelledby="table-header-1">

--- a/src/app/RecordingList/RecordingsDataTable.tsx
+++ b/src/app/RecordingList/RecordingsDataTable.tsx
@@ -36,7 +36,8 @@
  * SOFTWARE.
  */
 import * as React from 'react';
-import { Bullseye, DataList, DataListCell, DataListCheck, DataListItem, DataListItemCells, DataListItemRow, Spinner } from '@patternfly/react-core';
+import { Bullseye, DataList, DataListCell, DataListCheck, DataListItem, DataListItemCells, DataListItemRow, Spinner, Text } from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 export interface RecordingsDataTableProps {
   toolbar: React.ReactElement;
@@ -44,31 +45,46 @@ export interface RecordingsDataTableProps {
   listTitle: string;
   isHeaderChecked: boolean;
   isLoading: boolean;
+  errorMessage: string;
   onHeaderCheck: (checked: boolean) => void;
 }
 
 export const RecordingsDataTable: React.FunctionComponent<RecordingsDataTableProps> = (props) => {
-  return props.isLoading? (<>
-    <br/>
-    <Bullseye> 
-      <Spinner/>
-    </Bullseye>
-    </>) : (<>
-    { props.toolbar }
-    <DataList aria-label={props.listTitle}>
-      <DataListItem aria-labelledby="table-header-1">
-        <DataListItemRow>
-          <DataListCheck aria-labelledby="table-header-1" name="header-check" onChange={props.onHeaderCheck} isChecked={props.isHeaderChecked} />
-          <DataListItemCells
-            dataListCells={props.tableColumns.map((key , idx) => (
-              <DataListCell key={key}>
-                <span id={`table-header-${idx}`}>{key}</span>
-              </DataListCell>
-            ))}
-          />
-        </DataListItemRow>
-      </DataListItem>
-      { props.children }
-    </DataList>
-  </>);
+  if (props.errorMessage != '') {
+    return (<>
+      <br/>
+      <Bullseye>
+        <ExclamationCircleIcon size='md' color='Red'/>
+      </Bullseye>
+      <Bullseye>
+        <Text>
+          Unable to connect
+        </Text>
+      </Bullseye>
+    </>)
+  } else {
+    return props.isLoading? (<>
+      <br/>
+      <Bullseye> 
+        <Spinner/>
+      </Bullseye>
+      </>) : (<>
+      { props.toolbar }
+      <DataList aria-label={props.listTitle}>
+        <DataListItem aria-labelledby="table-header-1">
+          <DataListItemRow>
+            <DataListCheck aria-labelledby="table-header-1" name="header-check" onChange={props.onHeaderCheck} isChecked={props.isHeaderChecked} />
+            <DataListItemCells
+              dataListCells={props.tableColumns.map((key , idx) => (
+                <DataListCell key={key}>
+                  <span id={`table-header-${idx}`}>{key}</span>
+                </DataListCell>
+              ))}
+            />
+          </DataListItemRow>
+        </DataListItem>
+        { props.children }
+      </DataList>
+    </>);
+  }
 };


### PR DESCRIPTION
Fixes #133. Currently the loading spinner is visible while waiting for the user to input the JMX auth credentials. However, in the case of a connection failure (for example when cjfr does not have the cert file for the target in smoketest) the loading spinner just stays there forever. I think ideally an error message or icon should replace it, but doing so might require more changes to the Api.service.