### PR TITLE
Redundant recording list redraws, manual report refresh

### DIFF
--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -252,7 +252,6 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
           <br></br>
           <hr></hr>
           <br></br>
-          <Text>Automated Analysis:</Text>
           <ReportFrame recording={props.recording} width="100%" height="640" />
         </DataListContent>
       </DataListItem>

--- a/src/app/RecordingList/ReportFrame.tsx
+++ b/src/app/RecordingList/ReportFrame.tsx
@@ -40,7 +40,8 @@ import { NotificationsContext } from '@app/Notifications/Notifications';
 import { Recording } from '@app/Shared/Services/Api.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { Spinner } from '@patternfly/react-core';
+import { Button, Level, LevelItem, Spinner, Text } from '@patternfly/react-core';
+import { Spinner2Icon } from '@patternfly/react-icons';
 import { first } from 'rxjs/operators';
 
 export interface ReportFrameProps extends React.HTMLProps<HTMLIFrameElement> {
@@ -55,10 +56,10 @@ export const ReportFrame: React.FunctionComponent<ReportFrameProps> = React.memo
   const { recording, ...rest } = props;
   const addSubscription = useSubscriptions();
 
-  const handleReport = report => {
+  const handleReport = React.useCallback(report => {
     setReport(report);
     setLoaded(true);
-  };
+  }, []);
 
   const loadReport = React.useCallback(() => {
     setLoaded(false);
@@ -68,7 +69,7 @@ export const ReportFrame: React.FunctionComponent<ReportFrameProps> = React.memo
         err => notifications.danger(err),
       )
     );
-  }, [props.recording, setLoaded, addSubscription, context.reports, handleReport, notifications]);
+  }, [recording, setLoaded, addSubscription, context.reports, handleReport, notifications]);
 
   React.useLayoutEffect(() => {
     const sub = context.reports.report(recording).pipe(first()).subscribe(
@@ -82,6 +83,19 @@ export const ReportFrame: React.FunctionComponent<ReportFrameProps> = React.memo
 
   return (<>
     { !loaded && <Spinner /> }
+    <Level>
+      <LevelItem>
+        <Text>Automated Analysis:</Text>
+      </LevelItem>
+      <LevelItem>
+        <Button
+          isDisabled={!loaded}
+          onClick={loadReport}
+          variant='control'
+          icon={<Spinner2Icon />}
+        />
+      </LevelItem>
+    </Level>
     <iframe srcDoc={report} {...rest} onLoad={onLoad} hidden={!loaded} />
   </>);
 });

--- a/src/app/RecordingList/ReportFrame.tsx
+++ b/src/app/RecordingList/ReportFrame.tsx
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2020 Red Hat, Inc.
- * 
+ *
  * The Universal Permissive License (UPL), Version 1.0
- * 
+ *
  * Subject to the condition set forth below, permission is hereby granted to any
  * person obtaining a copy of this software, associated documentation and/or data
  * (collectively the "Software"), free of charge and under any and all copyright
@@ -10,23 +10,23 @@
  * licensable by each licensor hereunder covering either (i) the unmodified
  * Software as contributed to or provided by such licensor, or (ii) the Larger
  * Works (as defined below), to deal in both
- * 
+ *
  * (a) the Software, and
  * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
  * one is included with the Software (each a "Larger Work" to which the Software
  * is contributed by such licensors),
- * 
+ *
  * without restriction, including without limitation the rights to copy, create
  * derivative works of, display, perform, and distribute the Software and make,
  * use, sell, offer for sale, import, export, have made, and have sold the
  * Software and the Larger Work(s), and to sublicense the foregoing rights on
  * either these or other terms.
- * 
+ *
  * This license is subject to the following condition:
  * The above copyright notice and either this complete permission notice or at
  * a minimum a reference to the UPL must be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -39,6 +39,7 @@ import * as React from 'react';
 import { NotificationsContext } from '@app/Notifications/Notifications';
 import { Recording } from '@app/Shared/Services/Api.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { Spinner } from '@patternfly/react-core';
 import { first } from 'rxjs/operators';
 
@@ -49,17 +50,33 @@ export interface ReportFrameProps extends React.HTMLProps<HTMLIFrameElement> {
 export const ReportFrame: React.FunctionComponent<ReportFrameProps> = React.memo((props) => {
   const context = React.useContext(ServiceContext);
   const notifications = React.useContext(NotificationsContext);
-  const [report, setReport] = React.useState();
+  const [report, setReport] = React.useState(undefined as string | undefined);
   const [loaded, setLoaded] = React.useState(false);
   const { recording, ...rest } = props;
+  const addSubscription = useSubscriptions();
+
+  const handleReport = report => {
+    setReport(report);
+    setLoaded(true);
+  };
+
+  const loadReport = React.useCallback(() => {
+    setLoaded(false);
+    addSubscription(
+      context.reports.report(recording).pipe(first()).subscribe(
+        report => handleReport(report),
+        err => notifications.danger(err),
+      )
+    );
+  }, [props.recording, setLoaded, addSubscription, context.reports, handleReport, notifications]);
 
   React.useLayoutEffect(() => {
     const sub = context.reports.report(recording).pipe(first()).subscribe(
-      setReport,
-      notifications.danger
+      report => handleReport(report),
+      err => notifications.danger(err),
     );
     return () =>  sub.unsubscribe();
-  }, [context.reports, notifications, recording, props, props.recording]);
+  }, [context.reports, notifications, recording, props, props.recording, handleReport]);
 
   const onLoad = () => setLoaded(true);
 

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -35,6 +35,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+import * as _ from 'lodash';
+
 export function accessibleRouteChangeHandler() {
   return window.setTimeout(() => {
     const mainContainer = document.getElementById('primary-app-container');
@@ -42,4 +45,16 @@ export function accessibleRouteChangeHandler() {
       mainContainer.focus();
     }
   }, 50);
+}
+
+export function arraysEqual(a: any[], b: any[], comparator = _.eq): boolean {
+  if (a.length != b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (!comparator(a[i], b[i])) {
+      return false;
+    }
+  }
+  return true;
 }


### PR DESCRIPTION
This PR aims to smooth out the experience using the recording lists by avoiding spurious redraws of the content when the data is refreshed. This is achieved by avoiding re-setting the state unless the data has truly changed by deep comparison of the array - ie a new element is added or an element is removed, or an inner property of an element changes (ex. recording state). If the incoming data compares equally to the existing data then the update is skipped, preventing a redraw. More critically this also prevents a reload of the report frame, reducing the occurrences of visual jitter as the redraw moves elements within the page. I have also added a manual refresh button to the report frame so that users can trigger a refresh of the analysis at will.