### PR TITLE
Use error response body as error detail message

### DIFF
--- a/src/app/RecordingList/ReportFrame.tsx
+++ b/src/app/RecordingList/ReportFrame.tsx
@@ -36,10 +36,11 @@
  * SOFTWARE.
  */
 import * as React from 'react';
-import { Recording } from '@app/Shared/Services/Api.service';
+import { Recording, isHttpError } from '@app/Shared/Services/Api.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { Spinner } from '@patternfly/react-core';
 import { first } from 'rxjs/operators';
+import { isGenerationError } from '@app/Shared/Services/Report.service';
 
 export interface ReportFrameProps extends React.HTMLProps<HTMLIFrameElement> {
   recording: Recording;
@@ -55,12 +56,12 @@ export const ReportFrame: React.FunctionComponent<ReportFrameProps> = React.memo
     const sub = context.reports.report(recording).pipe(
       first()
     ).subscribe(report => setReport(report), err => {
-      if (err.messageDetail != undefined) {
+      if (isGenerationError(err)) {
         err.messageDetail.pipe(first()).subscribe(detail => setReport(detail));
-      } else if (err.message != undefined) {
+      } else if (isHttpError(err)) {
         setReport(err.message);
       } else {
-        setReport(err);
+        setReport(JSON.stringify(err));
       }
     });
     return () =>  sub.unsubscribe();

--- a/src/app/RecordingList/ReportFrame.tsx
+++ b/src/app/RecordingList/ReportFrame.tsx
@@ -55,7 +55,9 @@ export const ReportFrame: React.FunctionComponent<ReportFrameProps> = React.memo
     const sub = context.reports.report(recording).pipe(
       first()
     ).subscribe(report => setReport(report), err => {
-      if (err.message != undefined) {
+      if (err.messageDetail != undefined) {
+        err.messageDetail.pipe(first()).subscribe(detail => setReport(detail));
+      } else if (err.message != undefined) {
         setReport(err.message);
       } else {
         setReport(err);

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -227,7 +227,7 @@ export class ApiService {
 
   uploadArchivedRecordingToGrafana(recordingName: string): Observable<boolean> {
     return this.sendRequest(
-        'v1', `recordings/${encodeURIComponent(recordingName)}/upload`, 
+        'v1', `recordings/${encodeURIComponent(recordingName)}/upload`,
         {
           method: 'POST',
         }
@@ -451,7 +451,9 @@ export class ApiService {
       } else if (error.httpResponse.status === 502) {
         this.target.setSslFailure();
       } else {
-        this.notifications.danger(`Request failed (Status ${error.httpResponse.status})`, error.message)
+        error.httpResponse.text().then(detail => {
+          this.notifications.danger(`Request failed (${error.httpResponse.status} ${error.message})`, detail);
+        });
       }
       throw error;
     }

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -43,7 +43,7 @@ import { Notifications } from '@app/Notifications/Notifications';
 
 type ApiVersion = "v1" | "v2";
 
-class HttpError extends Error {
+export class HttpError extends Error {
   readonly httpResponse: Response;
 
   constructor(httpResponse: Response) {
@@ -52,7 +52,7 @@ class HttpError extends Error {
   }
 }
 
-const isHttpError = (toCheck: any): toCheck is HttpError => {
+export const isHttpError = (toCheck: any): toCheck is HttpError => {
   if (!(toCheck instanceof Error)) {
     return false;
   }

--- a/src/app/Shared/Services/Report.service.tsx
+++ b/src/app/Shared/Services/Report.service.tsx
@@ -99,12 +99,12 @@ export class ReportService {
 
 }
 
-type GenerationError = Error & {
+export type GenerationError = Error & {
   status: number;
   messageDetail: Observable<string>;
 }
 
-const isGenerationError = (toCheck: any): toCheck is GenerationError => {
+export const isGenerationError = (toCheck: any): toCheck is GenerationError => {
   if ((toCheck as GenerationError).name === undefined) {
     return false;
   }


### PR DESCRIPTION
Do not expect response status message to contain additional details, rather these additional details are written in the response body

See also rh-jmc-team/container-jfr#322