### PR TITLE
Configure webpack bundle splitting

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -13,6 +13,28 @@ module.exports = {
       template: path.resolve(__dirname, 'src', 'index.html')
     }),
   ],
+  // https://medium.com/hackernoon/the-100-correct-way-to-split-your-chunks-with-webpack-f8a9df5b7758
+  optimization: {
+    runtimeChunk: 'single',
+    splitChunks: {
+      chunks: 'all',
+      maxInitialRequests: Infinity,
+      minSize: 0,
+      cacheGroups: {
+        vendor: {
+          test: /[\\/]node_modules[\\/]/,
+          name(module) {
+            // get the name. E.g. node_modules/packageName/not/this/part.js
+            // or node_modules/packageName
+            const packageName = module.context.match(/[\\/]node_modules[\\/](.*?)([\\/]|$)/)[1];
+
+            // npm package names are URL-safe, but some servers don't like @ symbols
+            return `npm.${packageName.replace('@', '')}`;
+          },
+        },
+      },
+    },
+  },
   module: {
     rules: [
       {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -23,6 +23,10 @@ module.exports = merge(common, {
   plugins: [
     new DotenvPlugin(),
   ],
+  output: {
+    filename: '[name].bundle.js',
+    path: path.resolve(__dirname, 'dist')
+  },
   module: {
     rules: [
       {

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -24,6 +24,10 @@ module.exports = merge(common, {
       path: './.env.prod',
     }),
   ],
+  output: {
+    filename: '[name].[contenthash].bundle.js',
+    path: path.resolve(__dirname, 'dist')
+  },
   module: {
     rules: [
       {


### PR DESCRIPTION
Adds configuration to split app.bundle.js so that the main app.bundle.js
contains generally only container-jfr-web assets, and dependencies
(node_modules) are split out into separate bundle files. The
app.bundle.js for production builds also gains a content hash part of
its filename (as do all vendored dependency bundles) to help ensure that
assets are not incorrectly cached by browsers or webservers.

This allows the client web browser to only download the portions of the
web-client that have changed when (re)visiting the application, reducing
load times. This also allows for better cache handling since
infrequently-updated dependencies do not need to be re-downloaded every
time the application is rebuilt.

Fixes #149