### PR TITLE
Support Notifications Channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@patternfly/react-icons": "^4.3.2",
     "@patternfly/react-styles": "^4.3.2",
     "@patternfly/react-table": "^4.3.2",
+    "@types/lodash": "^4.14.165",
     "express": "^4.17.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -172,7 +172,7 @@ export const EventTypes = () => {
     });
 
     setDisplayedTypes(rows);
-  }, [context.commandChannel, currentPage, perPage, filterTypesByText, openRow]);
+  }, [currentPage, perPage, filterTypesByText, openRow]);
 
   const onCurrentPage = (evt, currentPage) => {
     setOpenRow(-1);
@@ -203,7 +203,7 @@ export const EventTypes = () => {
   if (errorMessage != '') {
     return (<ErrorView message={errorMessage}/>)
   } else if (isLoading) {
-    return (<LoadingView/>) 
+    return (<LoadingView/>)
   } else {
     return (<>
       <Toolbar id="event-types-toolbar">

--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -344,11 +344,11 @@ export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = 
   const addSubscription = useSubscriptions();
 
   React.useEffect(() => {
-    const sub = context.commandChannel.grafanaDatasourceUrl()
+    const sub = context.notificationChannel.grafanaDatasourceUrl()
       .pipe(first())
       .subscribe(() => setGrafanaEnabled(true));
     return () => sub.unsubscribe();
-  }, [context.commandChannel]);
+  }, [context.notificationChannel]);
 
   const grafanaUpload = () => {
     notifications.info('Upload Started', `Recording "${props.recording.name}" uploading...`);
@@ -358,7 +358,7 @@ export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = 
       .subscribe(success => {
         if (success) {
           notifications.success('Upload Success', `Recording "${props.recording.name}" uploaded`);
-          context.commandChannel.grafanaDashboardUrl().pipe(first()).subscribe(url => window.open(url, '_blank'));
+          context.notificationChannel.grafanaDashboardUrl().pipe(first()).subscribe(url => window.open(url, '_blank'));
         }
       })
     );

--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -344,7 +344,7 @@ export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = 
   const addSubscription = useSubscriptions();
 
   React.useEffect(() => {
-    const sub = context.notificationChannel.grafanaDatasourceUrl()
+    const sub = context.api.grafanaDatasourceUrl()
       .pipe(first())
       .subscribe(() => setGrafanaEnabled(true));
     return () => sub.unsubscribe();
@@ -358,7 +358,7 @@ export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = 
       .subscribe(success => {
         if (success) {
           notifications.success('Upload Success', `Recording "${props.recording.name}" uploaded`);
-          context.notificationChannel.grafanaDashboardUrl().pipe(first()).subscribe(url => window.open(url, '_blank'));
+          context.api.grafanaDashboardUrl().pipe(first()).subscribe(url => window.open(url, '_blank'));
         }
       })
     );

--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -348,7 +348,7 @@ export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = 
       .pipe(first())
       .subscribe(() => setGrafanaEnabled(true));
     return () => sub.unsubscribe();
-  }, [context.notificationChannel]);
+  }, [context.api, notifications]);
 
   const grafanaUpload = () => {
     notifications.info('Upload Started', `Recording "${props.recording.name}" uploading...`);

--- a/src/app/RecordingList/RecordingList.tsx
+++ b/src/app/RecordingList/RecordingList.tsx
@@ -50,7 +50,7 @@ export const RecordingList = () => {
   const archiveUpdate = new Subject<void>();
 
   React.useEffect(() => {
-    const sub = context.notificationChannel.isArchiveEnabled().subscribe(setArchiveEnabled);
+    const sub = context.api.isArchiveEnabled().subscribe(setArchiveEnabled);
     return () => sub.unsubscribe();
   }, [context.notificationChannel]);
 

--- a/src/app/RecordingList/RecordingList.tsx
+++ b/src/app/RecordingList/RecordingList.tsx
@@ -50,9 +50,9 @@ export const RecordingList = () => {
   const archiveUpdate = new Subject<void>();
 
   React.useEffect(() => {
-    const sub = context.commandChannel.isArchiveEnabled().subscribe(setArchiveEnabled);
+    const sub = context.notificationChannel.isArchiveEnabled().subscribe(setArchiveEnabled);
     return () => sub.unsubscribe();
-  }, [context.commandChannel]);
+  }, [context.notificationChannel]);
 
   React.useEffect(() => {
     return () => archiveUpdate.complete();

--- a/src/app/RecordingList/RecordingList.tsx
+++ b/src/app/RecordingList/RecordingList.tsx
@@ -52,7 +52,7 @@ export const RecordingList = () => {
   React.useEffect(() => {
     const sub = context.api.isArchiveEnabled().subscribe(setArchiveEnabled);
     return () => sub.unsubscribe();
-  }, [context.notificationChannel]);
+  }, [context.api]);
 
   React.useEffect(() => {
     return () => archiveUpdate.complete();

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -35,7 +35,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import { from, Observable, ObservableInput, of, ReplaySubject } from 'rxjs';
+import { from, Observable, ObservableInput, of, ReplaySubject, forkJoin, throwError } from 'rxjs';
 import { fromFetch } from 'rxjs/fetch';
 import { catchError, combineLatest, concatMap, first, flatMap, map, tap } from 'rxjs/operators';
 import { TargetService } from './Target.service';
@@ -64,24 +64,59 @@ export class ApiService {
   private readonly token = new ReplaySubject<string>(1);
   private readonly authMethod = new ReplaySubject<string>(1);
   private readonly archiveEnabled = new ReplaySubject<boolean>(1);
+  private readonly grafanaDatasourceUrlSubject = new ReplaySubject<string>(1);
+  private readonly grafanaDashboardUrlSubject = new ReplaySubject<string>(1);
   readonly authority: string;
 
   constructor(
     private readonly target: TargetService,
     private readonly notifications: Notifications
   ) {
-     let apiAuthority = process.env.CONTAINER_JFR_AUTHORITY;
-     if (!apiAuthority) {
-       apiAuthority = '';
-     }
-     window.console.log(`Using API authority ${apiAuthority}`);
-     this.authority = apiAuthority;
+    let apiAuthority = process.env.CONTAINER_JFR_AUTHORITY;
+    if (!apiAuthority) {
+      apiAuthority = '';
+    }
+    window.console.log(`Using API authority ${apiAuthority}`);
+    this.authority = apiAuthority;
 
-   this.doGet('recordings').subscribe(() => {
-     this.archiveEnabled.next(true);
-   }, () => {
-     this.archiveEnabled.next(false);
-   });
+    this.doGet('recordings').subscribe(() => {
+      this.archiveEnabled.next(true);
+    }, () => {
+      this.archiveEnabled.next(false);
+    });
+
+    const getDatasourceURL = fromFetch(`${apiAuthority}/api/v1/grafana_datasource_url`)
+    .pipe(concatMap(resp => from(resp.json())));
+    const getDashboardURL = fromFetch(`${apiAuthority}/api/v1/grafana_dashboard_url`)
+    .pipe(concatMap(resp => from(resp.json())));
+
+    fromFetch(`${apiAuthority}/health`)
+      .pipe(
+        concatMap(resp => from(resp.json())),
+        concatMap((jsonResp: any) => {
+          if (jsonResp.dashboardAvailable && jsonResp.datasourceAvailable) {
+            return forkJoin([getDatasourceURL, getDashboardURL]);
+          } else {
+            const missing: string[] = [];
+            if (!jsonResp.dashboardAvailable) {
+              missing.push('dashboard URL');
+            }
+            if (!jsonResp.datasourceAvailable) {
+              missing.push('datasource URL');
+            }
+            const message = missing.join(', ') + ' unavailable';
+            return throwError(message);
+          }}))
+      .subscribe(
+        (url: any) => {
+          this.grafanaDatasourceUrlSubject.next(url[0].grafanaDatasourceUrl);
+          this.grafanaDashboardUrlSubject.next(url[1].grafanaDashboardUrl);
+        },
+        err => {
+          window.console.error(err);
+          this.notifications.danger('Grafana configuration not found', JSON.stringify(err));
+        }
+      );
   }
 
   checkAuth(token: string, method: string): Observable<boolean> {
@@ -280,6 +315,14 @@ export class ApiService {
       }),
       catchError((): ObservableInput<boolean> => of(false)),
     );
+  }
+
+  grafanaDatasourceUrl(): Observable<string> {
+    return this.grafanaDatasourceUrlSubject.asObservable();
+  }
+
+  grafanaDashboardUrl(): Observable<string> {
+    return this.grafanaDashboardUrlSubject.asObservable();
   }
 
   doGet<T>(path: string): Observable<T> {

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -63,19 +63,26 @@ export class ApiService {
 
   private readonly token = new ReplaySubject<string>(1);
   private readonly authMethod = new ReplaySubject<string>(1);
+  private readonly archiveEnabled = new ReplaySubject<boolean>(1);
   readonly authority: string;
 
-   constructor(
-     private readonly target: TargetService,
-     private readonly notifications: Notifications
-   ) {
-      let apiAuthority = process.env.CONTAINER_JFR_AUTHORITY;
-      if (!apiAuthority) {
-        apiAuthority = '';
-      }
-      window.console.log(`Using API authority ${apiAuthority}`);
-      this.authority = apiAuthority;
-   }
+  constructor(
+    private readonly target: TargetService,
+    private readonly notifications: Notifications
+  ) {
+     let apiAuthority = process.env.CONTAINER_JFR_AUTHORITY;
+     if (!apiAuthority) {
+       apiAuthority = '';
+     }
+     window.console.log(`Using API authority ${apiAuthority}`);
+     this.authority = apiAuthority;
+
+   this.doGet('recordings').subscribe(() => {
+     this.archiveEnabled.next(true);
+   }, () => {
+     this.archiveEnabled.next(false);
+   });
+  }
 
   checkAuth(token: string, method: string): Observable<boolean> {
     return fromFetch(`${this.authority}/api/v1/auth`, {
@@ -156,6 +163,10 @@ export class ApiService {
         first(),
       )
     ));
+  }
+
+  isArchiveEnabled(): Observable<boolean> {
+    return this.archiveEnabled.asObservable();
   }
 
   archiveRecording(recordingName: string): Observable<boolean> {

--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -42,11 +42,11 @@ import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
 import { concatMap, first } from 'rxjs/operators';
 import { ApiService } from './Api.service';
 
-export class CommandChannel {
+export class NotificationChannel {
 
   private ws: WebSocketSubject<any> | null = null;
   private readonly apiSvc: ApiService;
-  private readonly messages = new Subject<ResponseMessage<any>>();
+  private readonly messages = new Subject<NotificationMessage>();
   private readonly ready = new BehaviorSubject<boolean>(false);
   private readonly archiveEnabled = new ReplaySubject<boolean>(1);
   private readonly clientUrlSubject = new ReplaySubject<string>(1);
@@ -173,48 +173,5 @@ export class CommandChannel {
   }
 }
 
-export interface CommandMessage {
-  id: string;
-  command: string;
-  args?: string[];
-}
-
-export interface ResponseMessage<T> {
-  id?: string;
-  status: number;
-  commandName: string;
-  payload: T;
-}
-
-export interface SuccessMessage extends ResponseMessage<void> { }
-
-export function isSuccessMessage(m: ResponseMessage<any>): m is SuccessMessage {
-  return m.status === 0;
-}
-
-export interface StringMessage extends ResponseMessage<string> { }
-
-export function isStringMessage(m: ResponseMessage<any>): m is StringMessage {
-  return m.status === 0 && typeof m.payload === 'string';
-}
-
-export interface ListMessage extends ResponseMessage<any[]> { }
-
-export function isListMessage(m: ResponseMessage<any>): m is ListMessage {
-  return m.status === 0 && Array.isArray(m.payload);
-}
-
-export interface FailureMessage extends ResponseMessage<string> { }
-
-export function isFailureMessage(m: ResponseMessage<any>): m is FailureMessage {
-  return m.status < 0 && typeof m.payload === 'string';
-}
-
-export interface ExceptionMessage extends ResponseMessage<{ commandName: string; exception: string }> { }
-
-export function isExceptionMessage(m: ResponseMessage<any>): m is ExceptionMessage {
-  return m.status < 0
-    && m.payload != null
-    && m.payload.commandName != null && typeof m.payload.commandName === 'string'
-    && m.payload.exception != null && typeof m.payload.exception === 'string';
+export interface NotificationMessage {
 }

--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -45,17 +45,14 @@ import { ApiService } from './Api.service';
 export class NotificationChannel {
 
   private ws: WebSocketSubject<any> | null = null;
-  private readonly apiSvc: ApiService;
   private readonly messages = new Subject<NotificationMessage>();
   private readonly ready = new BehaviorSubject<boolean>(false);
   private readonly clientUrlSubject = new ReplaySubject<string>(1);
 
   constructor(
-    apiSvc: ApiService,
+    private readonly apiSvc: ApiService,
     private readonly notifications: Notifications
   ) {
-    this.apiSvc = apiSvc;
-
     fromFetch(`${this.apiSvc.authority}/api/v1/clienturl`)
       .pipe(concatMap(resp => from(resp.json())))
       .subscribe(

--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -39,7 +39,7 @@ import { Notifications } from '@app/Notifications/Notifications';
 import { BehaviorSubject, combineLatest, from, Observable, Subject } from 'rxjs';
 import { fromFetch } from 'rxjs/fetch';
 import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
-import { concatMap, first, map } from 'rxjs/operators';
+import { concatMap, filter, first, map } from 'rxjs/operators';
 import { ApiService } from './Api.service';
 
 export class NotificationChannel {
@@ -100,8 +100,8 @@ export class NotificationChannel {
     return this._ready.asObservable();
   }
 
-  messages(): Observable<NotificationMessage> {
-    return this._messages.asObservable();
+  messages(category: string): Observable<NotificationMessage> {
+    return this._messages.asObservable().pipe(filter(msg => msg.meta.category === category));
   }
 
   private logError(title: string, err: any): void {

--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -42,6 +42,8 @@ import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
 import { concatMap, filter, first, map } from 'rxjs/operators';
 import { ApiService } from './Api.service';
 
+const NOTIFICATION_CATEGORY = 'WS_CLIENT_ACTIVITY';
+
 export class NotificationChannel {
 
   private ws: WebSocketSubject<any> | null = null;
@@ -52,6 +54,12 @@ export class NotificationChannel {
     private readonly apiSvc: ApiService,
     private readonly notifications: Notifications
   ) {
+    this.messages(NOTIFICATION_CATEGORY).subscribe(v => {
+      const addr = Object.keys(v.message)[0];
+      const status = v.message[addr];
+      notifications.info('WebSocket Client Activity', `Client at ${addr} ${status}`);
+    });
+
     const clientUrl = fromFetch(`${this.apiSvc.authority}/api/v1/clienturl`)
       .pipe(
         concatMap(resp => from(resp.json())),

--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -48,7 +48,6 @@ export class NotificationChannel {
   private readonly apiSvc: ApiService;
   private readonly messages = new Subject<NotificationMessage>();
   private readonly ready = new BehaviorSubject<boolean>(false);
-  private readonly archiveEnabled = new ReplaySubject<boolean>(1);
   private readonly clientUrlSubject = new ReplaySubject<string>(1);
   private readonly grafanaDatasourceUrlSubject = new ReplaySubject<string>(1);
   private readonly grafanaDashboardUrlSubject = new ReplaySubject<string>(1);
@@ -95,12 +94,6 @@ export class NotificationChannel {
         },
         err => this.logError('Grafana configuration not found', err)
       );
-
-    apiSvc.doGet('recordings').subscribe(() => {
-      this.archiveEnabled.next(true);
-    }, () => {
-      this.archiveEnabled.next(false);
-    });
 
     this.clientUrl().pipe(
       first()
@@ -161,10 +154,6 @@ export class NotificationChannel {
 
   isReady(): Observable<boolean> {
     return this.ready.asObservable();
-  }
-
-  isArchiveEnabled(): Observable<boolean> {
-    return this.archiveEnabled.asObservable();
   }
 
   private logError(title: string, err: any): void {

--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -111,4 +111,17 @@ export class NotificationChannel {
 }
 
 export interface NotificationMessage {
+  meta: MessageMeta;
+  message: any;
+  serverTime: number;
+}
+
+export interface MessageMeta {
+  category: string;
+  type: MessageType;
+}
+
+export interface MessageType {
+  type: string;
+  subtype: string;
 }

--- a/src/app/Shared/Services/Services.tsx
+++ b/src/app/Shared/Services/Services.tsx
@@ -39,24 +39,24 @@ import * as React from 'react';
 import { NotificationsInstance } from '@app/Notifications/Notifications';
 import { TargetService, TargetInstance } from './Target.service';
 import { ApiService } from './Api.service';
-import { CommandChannel } from './CommandChannel.service';
+import { NotificationChannel } from './NotificationChannel.service';
 import { ReportService } from './Report.service';
 import { SettingsService } from './Settings.service';
 
 export interface Services {
   target: TargetService;
   api: ApiService;
-  commandChannel: CommandChannel;
+  notificationChannel: NotificationChannel;
   reports: ReportService;
   settings: SettingsService;
 }
 
 const api = new ApiService(TargetInstance, NotificationsInstance);
-const commandChannel = new CommandChannel(api, NotificationsInstance);
+const notificationChannel = new NotificationChannel(api, NotificationsInstance);
 const reports = new ReportService(api, NotificationsInstance);
 const settings = new SettingsService();
 
-const defaultServices: Services = { target: TargetInstance, api, commandChannel, reports, settings };
+const defaultServices: Services = { target: TargetInstance, api, notificationChannel, reports, settings };
 
 const ServiceContext: React.Context<Services> = React.createContext(defaultServices);
 

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -80,8 +80,7 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
   }, [context.notificationChannel, refreshTargetList]);
 
   React.useEffect(() => {
-    const sub = context.notificationChannel.messages()
-      .pipe(filter(v => v.meta.category === NOTIFICATION_CATEGORY))
+    const sub = context.notificationChannel.messages(NOTIFICATION_CATEGORY)
       .subscribe(v => {
         const evt: TargetDiscoveryEvent = v.message.event;
         switch (evt.kind) {

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -94,6 +94,14 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
               selectNone();
             }
             break;
+          case 'CHANGED':
+            setTargets(old => {
+              const filtered = _.filter(old, t => t.connectUrl !== evt.serviceRef.connectUrl);
+              const updated =_.unionBy(filtered, [evt.serviceRef], t => t.connectUrl);
+              onSelect(undefined, _.find(updated, t => t.connectUrl === selected.connectUrl), false);
+              return updated;
+            });
+            break;
           default:
             notifications.danger(`Bad ${NOTIFICATION_CATEGORY} message received`, `Unknown event type ${evt.kind}`);
             break;
@@ -190,6 +198,6 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
 }
 
 interface TargetDiscoveryEvent {
-  kind: 'LOST' | 'FOUND';
+  kind: 'LOST' | 'FOUND' | 'CHANGED';
   serviceRef: Target;
 }

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -70,11 +70,11 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
   }, [context.api]);
 
   React.useEffect(() => {
-    const sub = context.commandChannel.isReady()
+    const sub = context.notificationChannel.isReady()
       .pipe(filter(v => !!v), first())
       .subscribe(refreshTargetList);
     return () => sub.unsubscribe();
-  }, [context.commandChannel, refreshTargetList]);
+  }, [context.notificationChannel, refreshTargetList]);
 
   React.useLayoutEffect(() => {
     const sub = context.target.target().subscribe(setSelected);

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -158,12 +158,12 @@ const AppRoutes = () => {
   const [authenticated, setAuthenticated] = React.useState(false);
 
   React.useEffect(() => {
-    const sub = context.commandChannel
+    const sub = context.notificationChannel
       .isReady()
       .pipe(filter((v) => !v))
       .subscribe(() => setAuthenticated(false));
     return () => sub.unsubscribe();
-  }, [context.commandChannel]);
+  }, [context.notificationChannel]);
 
   return (
     <LastLocationProvider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -719,6 +719,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/lodash@^4.14.165":
+  version "4.14.165"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.165.tgz#74d55d947452e2de0742bad65270433b63a8c30f"
+  integrity sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg==
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"


### PR DESCRIPTION
Fixes #162

This heavily refactors, simplifies, and renames the `CommandChannel` to the `NotificationsChannel`, with some of the old functionality moved to the `ApiService`.

The new `NotificationsChannel` allows consumer components to subscribe to notifications sent by the ContainerJFR backend and respond in various ways. Two such consumers are included: the first is the `NotificationsChannel` itself, which displays a notification message box when `WS_CLIENT_ACTIVITY` notification messages are received (when a WebSocket client (dis) connects). The second is the `TargetSelect` component, which now listens for `TargetJvmDiscovery` notifications, which are emitted by the backend when async target discovery observes a new target appearing or an old target disappearing. The `TargetSelect` component uses this notification to update its own state, rather than relying on polling or the user manually requesting a refresh of the data.