### PR TITLE
Apply only-if-changed plugin to 'prod' builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   "private": true,
   "scripts": {
     "build": "webpack --config webpack.prod.js",
+    "clean": "rimraf dist",
+    "clean:cache": "rimraf dist/cache",
     "start": "node server.js",
     "start:dev": "webpack-dev-server --hot --color --progress --info=true --config webpack.dev.js",
     "test": "jest",
@@ -42,6 +44,7 @@
     "lodash": "^4.17.19",
     "mini-css-extract-plugin": "^0.9.0",
     "nanoid": "^3.0.2",
+    "only-if-changed-webpack-plugin": "^0.0.3",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "prettier": "^2.0.5",
     "prop-types": "^15.6.1",

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -5,6 +5,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const TerserJSPlugin = require('terser-webpack-plugin');
 const DotenvPlugin = require('dotenv-webpack');
+const OnlyIfChangedPlugin = require('only-if-changed-webpack-plugin');
 
 module.exports = merge(common, {
   mode: 'production',
@@ -22,6 +23,10 @@ module.exports = merge(common, {
     }),
     new DotenvPlugin({
       path: './.env.prod',
+    }),
+    new OnlyIfChangedPlugin({
+      cacheDirectory: path.join(process.cwd(), 'dist', 'cache'),
+      cacheIdentifier: {},
     }),
   ],
   output: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1343,6 +1343,11 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
+async@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+  integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
+
 async@^2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
@@ -6146,6 +6151,14 @@ onetime@^5.1.0:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+only-if-changed-webpack-plugin@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/only-if-changed-webpack-plugin/-/only-if-changed-webpack-plugin-0.0.3.tgz#d8502dfed61407247cb5bc8cc3d78e3df18fd180"
+  integrity sha512-OOwTJGuEiF4E2g5uTNv9E8LP/5MfnXpBtmunofWN1uYpselr+acrkmnc7DxB85ER3rFgQDO8dZv/ZKtns6Eobg==
+  dependencies:
+    async "^1.5.2"
+    mkdirp "^0.5.1"
 
 opener@^1.5.1:
   version "1.5.2"


### PR DESCRIPTION
Skip building if sources and dependencies are unchanged

This substantially speeds up clean rebuilds (from ~11s to ~700ms in my tests just now), which are often encountered when container-jfr-web is built as a submodule of ContainerJFR itself before packaging into an OCI container. This can be tested by simply running `yarn run build` repeatedly.