### PR TITLE
Do not refresh views when target selection cleared

### DIFF
--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -38,12 +38,13 @@
 import * as React from 'react';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { EventTemplate } from '@app/Shared/Services/Api.service';
+import {NO_TARGET} from '@app/Shared/Services/Target.service';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { ActionGroup, Button, FileUpload, Form, FormGroup, Modal, ModalVariant, Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem, TextInput } from '@patternfly/react-core';
 import { PlusIcon } from '@patternfly/react-icons';
 import { Table, TableBody, TableHeader, TableVariant, IAction, IRowData, IExtraData, ISortBy, SortByDirection, sortable } from '@patternfly/react-table';
 import { useHistory } from 'react-router-dom';
-import { concatMap, first } from 'rxjs/operators';
+import { concatMap, filter, first } from 'rxjs/operators';
 import { LoadingView } from '@app/LoadingView/LoadingView';
 import { ErrorView } from '@app/ErrorView/ErrorView';
 
@@ -105,6 +106,7 @@ export const EventTemplates = () => {
     addSubscription(
       context.target.target()
       .pipe(
+        filter(target => target !== NO_TARGET),
         first(),
         concatMap(target => context.api.doGet<EventTemplate[]>(`targets/${encodeURIComponent(target.connectUrl)}/templates`)),
       ).subscribe(value => handleTemplates(value), err => handleError(err))

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -37,10 +37,11 @@
  */
 import * as React from 'react';
 import { ServiceContext } from '@app/Shared/Services/Services';
+import {NO_TARGET} from '@app/Shared/Services/Target.service';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { Toolbar, ToolbarContent, ToolbarItem, ToolbarItemVariant, Pagination, TextInput } from '@patternfly/react-core';
 import { expandable, Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-table';
-import { concatMap, first } from 'rxjs/operators';
+import { concatMap, filter, first } from 'rxjs/operators';
 import { LoadingView } from '@app/LoadingView/LoadingView';
 import { ErrorView } from '@app/ErrorView/ErrorView';
 
@@ -105,6 +106,7 @@ export const EventTypes = () => {
     addSubscription(
       context.target.target()
         .pipe(
+          filter(target => target !== NO_TARGET),
           first(),
           concatMap(target => context.api.doGet<EventType[]>(`targets/${encodeURIComponent(target.connectUrl)}/events`)),
         )

--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -36,17 +36,18 @@
  * SOFTWARE.
  */
 
+import {NotificationsContext} from '@app/Notifications/Notifications';
+import {Recording, RecordingState} from '@app/Shared/Services/Api.service';
+import {ServiceContext} from '@app/Shared/Services/Services';
+import {NO_TARGET} from '@app/Shared/Services/Target.service';
+import {useSubscriptions} from '@app/utils/useSubscriptions';
+import {Button, DataListAction, DataListCell, DataListCheck, DataListContent, DataListItem, DataListItemCells, DataListItemRow, DataListToggle, Dropdown, DropdownItem, DropdownPosition, KebabToggle, Text, Toolbar, ToolbarContent, ToolbarItem} from '@patternfly/react-core';
 import * as React from 'react';
-import { NotificationsContext } from '@app/Notifications/Notifications';
-import { Recording, RecordingState } from '@app/Shared/Services/Api.service';
-import { ServiceContext } from '@app/Shared/Services/Services';
-import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { Button, DataListAction, DataListCell, DataListCheck, DataListContent, DataListItem, DataListItemCells, DataListItemRow, DataListToggle, Dropdown, DropdownItem, DropdownPosition, KebabToggle, Text, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
-import { useHistory, useRouteMatch } from 'react-router-dom';
-import { forkJoin, Observable } from 'rxjs';
-import { concatMap, first, tap } from 'rxjs/operators';
-import { RecordingsDataTable } from './RecordingsDataTable';
-import { ReportFrame } from './ReportFrame';
+import {useHistory, useRouteMatch} from 'react-router-dom';
+import {forkJoin, Observable} from 'rxjs';
+import {concatMap, filter, first} from 'rxjs/operators';
+import {RecordingsDataTable} from './RecordingsDataTable';
+import {ReportFrame} from './ReportFrame';
 
 export interface ActiveRecordingsListProps {
   archiveEnabled: boolean;
@@ -108,6 +109,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
     addSubscription(
       context.target.target()
       .pipe(
+        filter(target => target !== NO_TARGET),
         concatMap(target => context.api.doGet<Recording[]>(`targets/${encodeURIComponent(target.connectUrl)}/recordings`)),
         first(),
       ).subscribe(value => handleRecordings(value), err => handleError(err))


### PR DESCRIPTION
TargetViews are hidden when the target selection is cleared, so there is no need to attempt to update the contents. Furthermore, updating the contents with a cleared target results in a 404 response, since the request will be sent with an empty string for a targetId.

Fixes #170